### PR TITLE
JSONProvider: Add to PROVIDERS_DICT

### DIFF
--- a/src/sg_policy/providers/__init__.py
+++ b/src/sg_policy/providers/__init__.py
@@ -4,10 +4,11 @@ from .terraform_plan.handler import *
 from .infracost import provide as infracost_provider
 from .sg_workflow import provide as sg_wf_provider
 from .terraform_plan import provide as terraform_provider
-
+from .json import provide as json_provider
 
 PROVIDERS_DICT: Dict[str, Callable] = {
     "stackguardian/terraform_plan": terraform_provider,
     "stackguardian/infracost": infracost_provider,
     "stackguardian/sg_workflow": sg_wf_provider,
+    "stackguardian/json": json_provider,
 }

--- a/tests/providers/json/policy.json
+++ b/tests/providers/json/policy.json
@@ -1,7 +1,7 @@
 {
     "meta": {
         "version": "v1",
-        "required_provider": "json"
+        "required_provider": "stackguardian/json"
     },
     "evaluators": [
         {


### PR DESCRIPTION
So that it can be referred in policy files as stackguardian/json.

Followup of d8f17debf5e6f6acffaab0f0ed366ec11f3c5507