### PR TITLE
cli: Disable logging output when not --json

### DIFF
--- a/src/sg_policy/cli.py
+++ b/src/sg_policy/cli.py
@@ -93,9 +93,11 @@ def main(args=None) -> ExitStatus:
             )
             return ExitStatus.ERROR
 
-        if not args.json:
+        if args.json:
+            # Disable all logging output
+            logging.disable(logging.CRITICAL)
+        else:
             setup_logging(verbose=args.verbose)
-
 
         try:
             result = start_policy_evaluation(args.policyPath, args.inputPath)


### PR DESCRIPTION
Previously the log would still appear because it has a default config that would log everything above logging.INFO level