### PR TITLE
json_provider: Make key_path supports accessing arrays

### DIFF
--- a/src/tirith/providers/json/handler.py
+++ b/src/tirith/providers/json/handler.py
@@ -1,15 +1,44 @@
-import operator
+import pydash
 
-from functools import reduce
 from typing import Callable, Dict, List
 from ..common import create_result_dict
+
+
+class PydashPathNotFound:
+    pass
+
+
+def get_path_value_from_dict(key_path, input_dict):
+    # TODO: Make this function more general and then move it to common.py
+    splitted_attribute = key_path.split(".*.")
+    return _get_path_value_from_dict(splitted_attribute, input_dict)
+
+
+def _get_path_value_from_dict(splitted_paths, input_dict):
+    final_data = []
+    for i, expression in enumerate(splitted_paths):
+        intermediate_val = pydash.get(input_dict, expression, default=PydashPathNotFound)
+        if isinstance(intermediate_val, list) and i < len(splitted_paths) - 1:
+            for val in intermediate_val:
+                final_attributes = _get_path_value_from_dict(splitted_paths[1:], val)
+                for final_attribute in final_attributes:
+                    final_data.append(final_attribute)
+        elif i == len(splitted_paths) - 1 and intermediate_val is not PydashPathNotFound:
+            final_data.append(intermediate_val)
+        elif ".*" in expression:
+            intermediate_exp = expression.split(".*")
+            intermediate_data = pydash.get(input_dict, intermediate_exp[0], default=PydashPathNotFound)
+            if intermediate_data is not PydashPathNotFound and isinstance(intermediate_data, list):
+                for val in intermediate_data:
+                    final_data.append(val)
+    return final_data
 
 
 def get_value(provider_args: Dict, input_data: Dict) -> Dict:
     # Must be validated first whether the provider args are valid for this op type
     key_path: str = provider_args["key_path"]
 
-    result = reduce(operator.getitem, key_path.split("."), input_data)
+    result = get_path_value_from_dict(key_path, input_data)
     return create_result_dict(value=result, meta=None, err=None)
 
 


### PR DESCRIPTION
TODO: We need to move get_path_value_from_dict() to common because it is the same logic copied from terraform_plan provider