### PR TITLE
terraform_plan/direct_references: Skip the `destroy` action resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-beta.8] - 2023-11-13
+
+### Fixed
+- `terraform_plan/direct_references`: Fixed bug where `references_to` and `referenced_by` were not accounting the no-op resources
+- `json/get_value`: Fixed bug where `get_value` always return list of values even if the value is not a list
+
 ## [1.0.0-beta.7] - 2023-11-08
 
 ### Fixed

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def read(*names, **kwargs):
 
 setup(
     name="py-tirith",
-    version="1.0.0-beta.7",
+    version="1.0.0-beta.8",
     license="Apache",
     description="Tirith simplifies defining Policy as Code.",
     long_description_content_type="text/markdown",

--- a/src/tirith/__init__.py
+++ b/src/tirith/__init__.py
@@ -2,6 +2,6 @@
 tirith: Execute policies defined using Tirith (StackGuardian Policy Framework)
 """
 
-__version__ = "1.0.0-beta.7"
+__version__ = "1.0.0-beta.8"
 __author__ = "StackGuardian"
 __license__ = "Apache"

--- a/src/tirith/cli.py
+++ b/src/tirith/cli.py
@@ -84,7 +84,7 @@ def main(args=None) -> ExitStatus:
             action="store_true",
             help="Show detailed logs of from the run",
         )
-        parser.add_argument("--version", action="version", version="1.0.0-beta.7")
+        parser.add_argument("--version", action="version", version="1.0.0-beta.8")
 
         args = parser.parse_args()
 

--- a/src/tirith/providers/json/handler.py
+++ b/src/tirith/providers/json/handler.py
@@ -34,19 +34,20 @@ def _get_path_value_from_dict(splitted_paths, input_dict):
     return final_data
 
 
-def get_value(provider_args: Dict, input_data: Dict) -> Dict:
+def get_value(provider_args: Dict, input_data: Dict) -> List[dict]:
     # Must be validated first whether the provider args are valid for this op type
     key_path: str = provider_args["key_path"]
 
-    result = get_path_value_from_dict(key_path, input_data)
-    return create_result_dict(value=result, meta=None, err=None)
+    values = get_path_value_from_dict(key_path, input_data)
+    outputs = [create_result_dict(value=value, meta=None, err=None) for value in values]
+
+    return outputs
 
 
 SUPPORTED_OPS: Dict[str, Callable] = {"get_value": get_value}
 
 
 def provide(provider_args: Dict, input_data: Dict) -> List[Dict]:
-    results = []
     operation_type = provider_args["operation_type"]
 
     op_handler = SUPPORTED_OPS.get(operation_type)
@@ -55,9 +56,7 @@ def provide(provider_args: Dict, input_data: Dict) -> List[Dict]:
         # TODO: We should think of a mechanism to tell the core that this error message
         # should be marked as yellow so it gets the attention of the user,
         # perhaps by prefixing the error message with `WARN:` or `ERR:`
-        results.append(create_result_dict(err=f"operation_type: {operation_type} is not supported"))
-        return results
+        return [create_result_dict(err=f"operation_type: {operation_type} is not supported")]
 
-    result = op_handler(provider_args, input_data)
-    results.append(result)
+    results = op_handler(provider_args, input_data)
     return results

--- a/src/tirith/providers/terraform_plan/handler.py
+++ b/src/tirith/providers/terraform_plan/handler.py
@@ -224,8 +224,8 @@ def direct_references_operator_referenced_by(input_data: dict, provider_inputs: 
 
     # Loop for adding reference_target
     for resource_change in resource_changes:
-        if resource_change.get("type") != resource_type or resource_change.get("change", {}).get("actions") != [
-            "create"
+        if resource_change.get("type") != resource_type or resource_change.get("change", {}).get("actions") == [
+            "destroy"
         ]:
             continue
         reference_target_addresses.add(resource_change.get("address"))
@@ -288,8 +288,8 @@ def direct_references_operator_references_to(input_data: dict, provider_inputs: 
     is_resource_found = False
 
     for resource_change in resource_changes:
-        if resource_change.get("type") != resource_type or resource_change.get("change", {}).get("actions") != [
-            "create"
+        if resource_change.get("type") != resource_type or resource_change.get("change", {}).get("actions") == [
+            "destroy"
         ]:
             continue
         is_resource_found = True

--- a/tests/providers/json/input.json
+++ b/tests/providers/json/input.json
@@ -2,5 +2,18 @@
 	"a": {
 			"b": 1
 		},
-	"c": ["aa", "bb"]
+	"c": ["aa", "bb"],
+	"nested_map": {
+		"e": {
+			"f": "3"
+		}
+	},
+	"list_of_dict": [
+		{
+			"key1": "value1"
+		},
+		{
+			"key1": "value1"
+		}
+	]
 }

--- a/tests/providers/json/policy.json
+++ b/tests/providers/json/policy.json
@@ -22,10 +22,43 @@
                 "key_path": "c"
             },
             "condition": {
-                "type": "ContainedIn",
+                "type": "Contains",
                 "value": "aa"
+            }
+        },
+        {
+            "id": "check3",
+            "provider_args": {
+                "operation_type": "get_value",
+                "key_path": "nested_map.e.f"
+            },
+            "condition": {
+                "type": "Equals",
+                "value": "3"
+            }
+        },
+        {
+            "id": "check4",
+            "provider_args": {
+                "operation_type": "get_value",
+                "key_path": "list_of_dict.*.key1"
+            },
+            "condition": {
+                "type": "Equals",
+                "value": "value1"
+            }
+        },
+        {
+            "id": "check5",
+            "provider_args": {
+                "operation_type": "get_value",
+                "key_path": "nested_map"
+            },
+            "condition": {
+                "type": "Equals",
+                "value": { "e": { "f": "3" } }
             }
         }
     ],
-    "eval_expression": "check1 && check2"
+    "eval_expression": "check1 && check2 && check3 && check4 && check5"
 }


### PR DESCRIPTION
Instead of just excluding resources that don't have the actions==create, we just exclude the resources that are of action==destroy. Because there's also actions==no-op