### PR TITLE
evaluator/regex_match: Use `re.search()` instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-beta.9] - 2023-11-16
+
+### Added
+- `terraform_plan`: Add `terraform_version` operation type to get the terraform version from the plan file
+- `terraform_plan`: Add `provider_config` operation type to get the provider config from the plan file, like checking for the `region` in the `aws` provider, and the version of the provider
+
+### Fixed
+- `evaluator/RegexMatch`: Change the method to check regex match to `re.search` instead of `re.match` to make sure the regex is matched anywhere in the string
+
 ## [1.0.0-beta.8] - 2023-11-13
 
 ### Fixed

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def read(*names, **kwargs):
 
 setup(
     name="py-tirith",
-    version="1.0.0-beta.8",
+    version="1.0.0-beta.9",
     license="Apache",
     description="Tirith simplifies defining Policy as Code.",
     long_description_content_type="text/markdown",

--- a/src/tirith/__init__.py
+++ b/src/tirith/__init__.py
@@ -2,6 +2,6 @@
 tirith: Execute policies defined using Tirith (StackGuardian Policy Framework)
 """
 
-__version__ = "1.0.0-beta.8"
+__version__ = "1.0.0-beta.9"
 __author__ = "StackGuardian"
 __license__ = "Apache"

--- a/src/tirith/cli.py
+++ b/src/tirith/cli.py
@@ -84,7 +84,7 @@ def main(args=None) -> ExitStatus:
             action="store_true",
             help="Show detailed logs of from the run",
         )
-        parser.add_argument("--version", action="version", version="1.0.0-beta.8")
+        parser.add_argument("--version", action="version", version="1.0.0-beta.9")
 
         args = parser.parse_args()
 

--- a/src/tirith/core/evaluators/regex_match.py
+++ b/src/tirith/core/evaluators/regex_match.py
@@ -9,7 +9,7 @@ class RegexMatch(BaseEvaluator):
             match = 0
             if type(evaluator_input) in (str, list, dict) and type(evaluator_data) == str:
                 evaluator_input = str(evaluator_input)
-                match = re.match(evaluator_data, evaluator_input)
+                match = re.search(evaluator_data, evaluator_input)
                 if match is None:
                     evaluation_result = {
                         "passed": False,

--- a/src/tirith/providers/terraform_plan/handler.py
+++ b/src/tirith/providers/terraform_plan/handler.py
@@ -163,6 +163,8 @@ def provide(provider_inputs, input_data):
         direct_dependencies_operator(input_data, provider_inputs, outputs)
     elif input_type == "direct_references":
         direct_references_operator(input_data, provider_inputs, outputs)
+    elif input_type == "terraform_version":
+        terraform_version_operator(input_data, provider_inputs, outputs)
     else:
         outputs.append(
             {
@@ -171,6 +173,17 @@ def provide(provider_inputs, input_data):
             }
         )
     return outputs
+
+
+def terraform_version_operator(input_data: dict, provider_inputs: dict, outputs: list):
+    """
+    Operation type handler to get the terraform version from terraform plan
+
+    :param input_data:      The input data
+    :param provider_inputs: The provider inputs
+    :param outputs:         The outputs
+    """
+    outputs.append({"value": input_data.get("terraform_version"), "meta": input_data})
 
 
 def direct_dependencies_operator(input_data: dict, provider_inputs: dict, outputs: list):

--- a/tests/core/evaluators/test_regex_match.py
+++ b/tests/core/evaluators/test_regex_match.py
@@ -32,3 +32,54 @@ def test_regex_list():
 def test_regex_dict():
     result = evaluator.evaluate(evaluator_input=dict(a=2), evaluator_data=r"{'a': 2}")
     assert result["passed"] is True
+
+
+def test_multiline_string_match_with_simple_regex():
+    evaluator_input = """
+    {
+      "costcenter":"123",
+      "test":123
+    }
+    """
+    result = evaluator.evaluate(evaluator_input=evaluator_input, evaluator_data=r"costcenter")
+    assert result["passed"] is True
+
+
+def test_multiline_string_match_with_full_regex():
+    evaluator_input = """
+    {
+      "costcenter":"123",
+      "test":123
+    }
+    """
+    result = evaluator.evaluate(evaluator_input=evaluator_input, evaluator_data=r".*costcenter.*")
+    assert result["passed"] is True
+
+
+def test_multiline_string_match_with_full_regex_should_fail():
+    evaluator_input = """
+    {
+      "costcenter":"123",
+      "test":123
+    }
+    """
+    result = evaluator.evaluate(evaluator_input=evaluator_input, evaluator_data=r"^costcenter$")
+    assert result["passed"] is False
+
+
+def test_singleline_string_match_with_simple_regex():
+    evaluator_input = '{ "costcenter":"123", "test":123 }'
+    result = evaluator.evaluate(evaluator_input=evaluator_input, evaluator_data=r"costcenter")
+    assert result["passed"] is True
+
+
+def test_singleline_string_match_with_full_regex():
+    evaluator_input = '{ "costcenter":"123", "test":123 }'
+    result = evaluator.evaluate(evaluator_input=evaluator_input, evaluator_data=r".*costcenter.*")
+    assert result["passed"] is True
+
+
+def test_singleline_string_match_with_fullmatch_regex():
+    evaluator_input = '{ "costcenter":"123", "test":123 }'
+    result = evaluator.evaluate(evaluator_input=evaluator_input, evaluator_data=r'^{ "costcenter":"123", "test":123 }$')
+    assert result["passed"] is True

--- a/tests/providers/terraform_plan/test_provider_config.py
+++ b/tests/providers/terraform_plan/test_provider_config.py
@@ -1,0 +1,41 @@
+from tirith.providers.common import ProviderError
+from tirith.providers.terraform_plan import handler
+from utils import load_terraform_plan_json
+
+
+def test_get_terraform_provider_get_region():
+    provider_args_dict = {
+        "operation_type": "provider_config",
+        "terraform_provider_full_name": "registry.terraform.io/hashicorp/aws",
+        "attribute": "region",
+    }
+    result = handler.provide(provider_args_dict, load_terraform_plan_json("input_instance_deps_s3.json"))
+
+    assert len(result) == 1
+    assert result[0]["value"] == "eu-central-1"
+
+
+def test_get_terraform_provider_get_version_constraint_not_found():
+    provider_args_dict = {
+        "operation_type": "provider_config",
+        "terraform_provider_full_name": "registry.terraform.io/hashicorp/aws",
+        "attribute": "version_constraint",
+    }
+    result = handler.provide(provider_args_dict, load_terraform_plan_json("input_instance_deps_s3.json"))
+
+    assert len(result) == 1
+    assert isinstance(result[0]["value"], ProviderError)
+    assert result[0]["value"].severity_value == 2
+    assert result[0]["err"] == "version_constraint is not found in the provider_config (severity_value: 2)"
+
+
+def test_get_terraform_provider_get_version_constraint():
+    provider_args_dict = {
+        "operation_type": "provider_config",
+        "terraform_provider_full_name": "registry.terraform.io/hashicorp/azurerm",
+        "attribute": "version_constraint",
+    }
+    result = handler.provide(provider_args_dict, load_terraform_plan_json("input_vnet_destroy_new.json"))
+
+    assert len(result) == 1
+    assert result[0]["value"] == ">= 3.11.0, < 4.0.0"

--- a/tests/providers/terraform_plan/test_terraform_plan.py
+++ b/tests/providers/terraform_plan/test_terraform_plan.py
@@ -107,3 +107,11 @@ def test_direct_references():
     assert len(result) == 2
     assert result[0]["value"] == ["aws_security_group"]
     assert result[1]["value"] == []
+
+
+def test_get_terraform_version():
+    provider_args_dict = {"operation_type": "terraform_version"}
+    result = handler.provide(provider_args_dict, load_terraform_plan_json("input_instance_deps_s3.json"))
+
+    assert len(result) == 1
+    assert result[0]["value"] == "1.4.5"


### PR DESCRIPTION
`re.match()` doesn't work if the pattern doesn't occur in the beginning of the string