### PR TITLE
Centralized version definition to simplify version bumping process

### DIFF
--- a/src/tirith/cli.py
+++ b/src/tirith/cli.py
@@ -12,6 +12,7 @@ import tirith.providers.terraform_plan.handler as python_tf_plan_handler
 from tirith.logging import setup_logging
 from tirith.prettyprinter import pretty_print_result_dict
 from tirith.status import ExitStatus
+from tirith import __version__
 
 from .core import start_policy_evaluation
 
@@ -84,7 +85,7 @@ def main(args=None) -> ExitStatus:
             action="store_true",
             help="Show detailed logs of from the run",
         )
-        parser.add_argument("--version", action="version", version="1.0.0-beta.12")
+        parser.add_argument("--version", action="version", version=__version__)
 
         args = parser.parse_args()
 


### PR DESCRIPTION
This PR aims to enhance our version management process by centralizing the version definition, making it easier to bump versions across the project.

Current behavior:
The version number is defined in multiple places across the project, including 'cli.py' and '__init__.py'. When bumping the version, we need to search and replace the version string in all these files.

Proposed change:
1. Centralize the version definition in a single location (i.e, '__init__.py').
2. Update other modules, such as 'cli.py', to import and use the centralized version definition.
