### PR TITLE
Simplify type checking in sort_collections()  Closes https://github.com/StackGuardian/tirith/issues/185

### DIFF
--- a/src/tirith/utils.py
+++ b/src/tirith/utils.py
@@ -5,7 +5,7 @@ logger = logging.getLogger(__name__)
 
 def sort_collections(inputs):
     try:
-        if isinstance(inputs, str) or isinstance(inputs, float) or isinstance(inputs, int) or isinstance(inputs, bool):
+        if isinstance(inputs, (str, float, int, bool)):
             return inputs
         elif isinstance(inputs, list):
             if len(inputs) == 0:


### PR DESCRIPTION
Update the sort_collections function in the utils.py to use a single isinstance check for primitive types.