### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pydosctyle.yml
+++ b/.github/workflows/pydosctyle.yml
@@ -2,6 +2,9 @@ name: Lint and Test
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/StackGuardian/tirith/security/code-scanning/18](https://github.com/StackGuardian/tirith/security/code-scanning/18)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since the workflow only performs linting and testing tasks, it does not require any write permissions. The minimal permission required is `contents: read`, which allows the workflow to read the repository contents. This change ensures adherence to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
