### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
 
 jobs:
   deploy:


### PR DESCRIPTION
Potential fix for [https://github.com/StackGuardian/tirith/security/code-scanning/17](https://github.com/StackGuardian/tirith/security/code-scanning/17)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required. Since the workflow involves deploying to GitHub Pages, it needs `contents: write` permissions. All other permissions will be omitted to adhere to the principle of least privilege.

The `permissions` block will be added at the root level of the workflow, ensuring it applies to all jobs unless overridden by a job-specific `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
