### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Linting
+permissions:
+  contents: read
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/StackGuardian/tirith/security/code-scanning/16](https://github.com/StackGuardian/tirith/security/code-scanning/16)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only performs linting, it requires minimal permissions. Specifically, we will set `contents: read` to allow the workflow to read the repository contents. This change ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
