### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   run_test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/StackGuardian/tirith/security/code-scanning/15](https://github.com/StackGuardian/tirith/security/code-scanning/15)

To fix the issue, we will add a `permissions` block at the workflow level (root) to explicitly define the minimal permissions required. Since this workflow only checks out the repository and installs dependencies, it only needs `contents: read` permission. This ensures that the `GITHUB_TOKEN` is restricted to read-only access to the repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
