### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,7 @@
 name: Coverage
 on: [push, pull_request]
+permissions:
+  contents: read
 jobs:
   coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/StackGuardian/tirith/security/code-scanning/14](https://github.com/StackGuardian/tirith/security/code-scanning/14)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps:
- `contents: read` is needed to check out the repository code.
- `contents: write` is required to upload coverage reports to Codecov, as it may involve creating or modifying files in the repository.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
