### PR TITLE
feat(terraform_plan): enhance attribute retrieval with missing attrib…

### DIFF
--- a/tests/providers/terraform_plan/fixtures/input_aws_instance_ebs.json
+++ b/tests/providers/terraform_plan/fixtures/input_aws_instance_ebs.json
@@ -1,0 +1,366 @@
+{
+    "format_version": "1.2",
+    "terraform_version": "1.11.4",
+    "planned_values": {
+      "root_module": {
+        "resources": [
+          {
+            "address": "aws_instance.example",
+            "mode": "managed",
+            "type": "aws_instance",
+            "name": "example",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "schema_version": 1,
+            "values": {
+              "ami": "ami-099a8245f5daa82bf",
+              "availability_zone": "eu-west-1a",
+              "credit_specification": [],
+              "ebs_block_device": [
+                {
+                  "delete_on_termination": true,
+                  "device_name": "/dev/sdf",
+                  "tags": { "Name": "EC2-with-3-EBS" },
+                  "volume_size": 10
+                },
+                {
+                  "delete_on_termination": true,
+                  "device_name": "/dev/sdg",
+                  "tags": {
+                    "Name": "EC2-with-3-EBS",
+                    "application_acronym": "TTO"
+                  },
+                  "volume_size": 10
+                },
+                {
+                  "delete_on_termination": true,
+                  "device_name": "/dev/sdh",
+                  "tags": {
+                    "Name": "EC2-with-3-EBS",
+                    "application_acronym": "TTO"
+                  },
+                  "volume_size": 10
+                }
+              ],
+              "get_password_data": false,
+              "hibernation": null,
+              "instance_type": "m5.4xlarge",
+              "launch_template": [],
+              "root_block_device": [
+                {
+                  "delete_on_termination": false,
+                  "tags": {
+                    "Name": "EC2-with-3-EBS",
+                    "application_acronym": "TTO"
+                  },
+                  "volume_size": 8
+                }
+              ],
+              "source_dest_check": true,
+              "tags": { "Name": "EC2-with-3-EBS", "application_acronym": "TTO" },
+              "tags_all": {
+                "Name": "EC2-with-3-EBS",
+                "application_acronym": "TTO"
+              },
+              "timeouts": null,
+              "user_data_replace_on_change": false,
+              "volume_tags": null
+            },
+            "sensitive_values": {
+              "capacity_reservation_specification": [],
+              "cpu_options": [],
+              "credit_specification": [],
+              "ebs_block_device": [
+                { "tags": {}, "tags_all": {} },
+                { "tags": {}, "tags_all": {} },
+                { "tags": {}, "tags_all": {} }
+              ],
+              "enclave_options": [],
+              "ephemeral_block_device": [],
+              "instance_market_options": [],
+              "ipv6_addresses": [],
+              "launch_template": [],
+              "maintenance_options": [],
+              "metadata_options": [],
+              "network_interface": [],
+              "private_dns_name_options": [],
+              "root_block_device": [{ "tags": {}, "tags_all": {} }],
+              "secondary_private_ips": [],
+              "security_groups": [],
+              "tags": {},
+              "tags_all": {},
+              "vpc_security_group_ids": []
+            }
+          }
+        ]
+      }
+    },
+    "resource_changes": [
+      {
+        "address": "aws_instance.example",
+        "mode": "managed",
+        "type": "aws_instance",
+        "name": "example",
+        "provider_name": "registry.terraform.io/hashicorp/aws",
+        "change": {
+          "actions": ["create"],
+          "before": null,
+          "after": {
+            "ami": "ami-099a8245f5daa82bf",
+            "availability_zone": "eu-west-1a",
+            "credit_specification": [],
+            "ebs_block_device": [
+              {
+                "delete_on_termination": true,
+                "device_name": "/dev/sdf",
+                "tags": { "Name": "EC2-with-3-EBS" },
+                "volume_size": 10
+              },
+              {
+                "delete_on_termination": true,
+                "device_name": "/dev/sdg",
+                "tags": {
+                  "Name": "EC2-with-3-EBS",
+                  "application_acronym": "TTO"
+                },
+                "volume_size": 10
+              },
+              {
+                "delete_on_termination": true,
+                "device_name": "/dev/sdh",
+                "tags": {
+                  "Name": "EC2-with-3-EBS",
+                  "application_acronym": "TTO"
+                },
+                "volume_size": 10
+              }
+            ],
+            "get_password_data": false,
+            "hibernation": null,
+            "instance_type": "m5.4xlarge",
+            "launch_template": [],
+            "root_block_device": [
+              {
+                "delete_on_termination": false,
+                "tags": {
+                  "Name": "EC2-with-3-EBS",
+                  "application_acronym": "TTO"
+                },
+                "volume_size": 8
+              }
+            ],
+            "source_dest_check": true,
+            "tags": { "Name": "EC2-with-3-EBS", "application_acronym": "TTO" },
+            "tags_all": {
+              "Name": "EC2-with-3-EBS",
+              "application_acronym": "TTO"
+            },
+            "timeouts": null,
+            "user_data_replace_on_change": false,
+            "volume_tags": null
+          },
+          "after_unknown": {
+            "arn": true,
+            "associate_public_ip_address": true,
+            "capacity_reservation_specification": true,
+            "cpu_core_count": true,
+            "cpu_options": true,
+            "cpu_threads_per_core": true,
+            "credit_specification": [],
+            "disable_api_stop": true,
+            "disable_api_termination": true,
+            "ebs_block_device": [
+              {
+                "encrypted": true,
+                "iops": true,
+                "kms_key_id": true,
+                "snapshot_id": true,
+                "tags": {},
+                "tags_all": true,
+                "throughput": true,
+                "volume_id": true,
+                "volume_type": true
+              },
+              {
+                "encrypted": true,
+                "iops": true,
+                "kms_key_id": true,
+                "snapshot_id": true,
+                "tags": {},
+                "tags_all": true,
+                "throughput": true,
+                "volume_id": true,
+                "volume_type": true
+              },
+              {
+                "encrypted": true,
+                "iops": true,
+                "kms_key_id": true,
+                "snapshot_id": true,
+                "tags": {},
+                "tags_all": true,
+                "throughput": true,
+                "volume_id": true,
+                "volume_type": true
+              }
+            ],
+            "ebs_optimized": true,
+            "enable_primary_ipv6": true,
+            "enclave_options": true,
+            "ephemeral_block_device": true,
+            "host_id": true,
+            "host_resource_group_arn": true,
+            "iam_instance_profile": true,
+            "id": true,
+            "instance_initiated_shutdown_behavior": true,
+            "instance_lifecycle": true,
+            "instance_market_options": true,
+            "instance_state": true,
+            "ipv6_address_count": true,
+            "ipv6_addresses": true,
+            "key_name": true,
+            "launch_template": [],
+            "maintenance_options": true,
+            "metadata_options": true,
+            "monitoring": true,
+            "network_interface": true,
+            "outpost_arn": true,
+            "password_data": true,
+            "placement_group": true,
+            "placement_partition_number": true,
+            "primary_network_interface_id": true,
+            "private_dns": true,
+            "private_dns_name_options": true,
+            "private_ip": true,
+            "public_dns": true,
+            "public_ip": true,
+            "root_block_device": [
+              {
+                "device_name": true,
+                "encrypted": true,
+                "iops": true,
+                "kms_key_id": true,
+                "tags": {},
+                "tags_all": true,
+                "throughput": true,
+                "volume_id": true,
+                "volume_type": true
+              }
+            ],
+            "secondary_private_ips": true,
+            "security_groups": true,
+            "spot_instance_request_id": true,
+            "subnet_id": true,
+            "tags": {},
+            "tags_all": {},
+            "tenancy": true,
+            "user_data": true,
+            "user_data_base64": true,
+            "vpc_security_group_ids": true
+          },
+          "before_sensitive": false,
+          "after_sensitive": {
+            "capacity_reservation_specification": [],
+            "cpu_options": [],
+            "credit_specification": [],
+            "ebs_block_device": [
+              { "tags": {}, "tags_all": {} },
+              { "tags": {}, "tags_all": {} },
+              { "tags": {}, "tags_all": {} }
+            ],
+            "enclave_options": [],
+            "ephemeral_block_device": [],
+            "instance_market_options": [],
+            "ipv6_addresses": [],
+            "launch_template": [],
+            "maintenance_options": [],
+            "metadata_options": [],
+            "network_interface": [],
+            "private_dns_name_options": [],
+            "root_block_device": [{ "tags": {}, "tags_all": {} }],
+            "secondary_private_ips": [],
+            "security_groups": [],
+            "tags": {},
+            "tags_all": {},
+            "vpc_security_group_ids": []
+          }
+        }
+      }
+    ],
+    "configuration": {
+      "provider_config": {
+        "aws": {
+          "name": "aws",
+          "full_name": "registry.terraform.io/hashicorp/aws",
+          "expressions": { "region": { "constant_value": "eu-west-1" } }
+        }
+      },
+      "root_module": {
+        "resources": [
+          {
+            "address": "aws_instance.example",
+            "mode": "managed",
+            "type": "aws_instance",
+            "name": "example",
+            "provider_config_key": "aws",
+            "expressions": {
+              "ami": { "constant_value": "ami-099a8245f5daa82bf" },
+              "availability_zone": { "constant_value": "eu-west-1a" },
+              "ebs_block_device": [
+                {
+                  "device_name": { "constant_value": "/dev/sdf" },
+                  "tags": { "constant_value": { "Name": "EC2-with-3-EBS" } },
+                  "volume_size": { "constant_value": 10 }
+                },
+                {
+                  "delete_on_termination": { "constant_value": true },
+                  "device_name": { "constant_value": "/dev/sdg" },
+                  "tags": {
+                    "constant_value": {
+                      "Name": "EC2-with-3-EBS",
+                      "application_acronym": "TTO"
+                    }
+                  },
+                  "volume_size": { "constant_value": 10 }
+                },
+                {
+                  "device_name": { "constant_value": "/dev/sdh" },
+                  "tags": {
+                    "constant_value": {
+                      "Name": "EC2-with-3-EBS",
+                      "application_acronym": "TTO"
+                    }
+                  },
+                  "volume_size": { "constant_value": 10 }
+                }
+              ],
+              "instance_type": { "constant_value": "m5.4xlarge" },
+              "root_block_device": [
+                {
+                  "delete_on_termination": { "constant_value": false },
+                  "tags": {
+                    "constant_value": {
+                      "Name": "EC2-with-3-EBS",
+                      "application_acronym": "TTO"
+                    }
+                  },
+                  "volume_size": { "constant_value": 8 }
+                }
+              ],
+              "tags": {
+                "constant_value": {
+                  "Name": "EC2-with-3-EBS",
+                  "application_acronym": "TTO"
+                }
+              }
+            },
+            "schema_version": 1
+          }
+        ]
+      }
+    },
+    "timestamp": "2025-05-06T10:51:35Z",
+    "applyable": true,
+    "complete": true,
+    "errored": false
+  }
+  

--- a/tests/providers/terraform_plan/fixtures/policy_aws_instance_ebs.json
+++ b/tests/providers/terraform_plan/fixtures/policy_aws_instance_ebs.json
@@ -1,0 +1,37 @@
+{
+    "evaluators": [
+      {
+        "description": "",
+        "condition": {
+          "type": "IsNotEmpty",
+          "value": "",
+          "error_tolerance": 0
+        },
+        "id": "eval-id-1",
+        "provider_args": {
+          "operation_type": "attribute",
+          "terraform_resource_attribute": "tags.application_acronym",
+          "terraform_resource_type": "*"
+        }
+      },
+      {
+        "description": "",
+        "condition": {
+          "type": "IsNotEmpty",
+          "value": "",
+          "error_tolerance": 0
+        },
+        "id": "eval-id-2",
+        "provider_args": {
+          "operation_type": "attribute",
+          "terraform_resource_attribute": "ebs_block_device.*.tags.application_acronym",
+          "terraform_resource_type": "aws_instance"
+        }
+      }
+    ],
+    "meta": {
+      "required_provider": "stackguardian/terraform_plan",
+      "version": "v1"
+    },
+    "eval_expression": "eval-id-1 && eval-id-2"
+  }


### PR DESCRIPTION
Issue Summary: EBS Block Device Tag Validation Bug
The Problem
The policy was incorrectly passing even though one of the EBS block devices (device /dev/sdf) was missing the required application_acronym tag. This happened because:

The policy used ebs_block_device.*.tags.application_acronym to check that all EBS devices had the tag
The evaluation logic was flawed - it was collecting only successful matches and silently ignoring missing attributes
Since two out of three EBS devices had the tag, the result was non-empty, causing the evaluator to pass
Root Cause
The bug was in the _get_exp_attribute function in handler.py. When processing wildcard expressions like ebs_block_device.*.tags.application_acronym, the function was:

Accumulating all values it found (e.g., "TTO" from two of the devices)
Not tracking or reporting when attributes were missing from some elements
Considering the overall evaluation successful if any matches were found
The Fix
The fix involved two key changes:

Track Missing Attributes: Modified _get_exp_attribute to return both the found values and a list of missing attributes

Fail on Missing Attributes: Updated _wrapper_get_exp_attribute to check if any attributes are missing and fail the evaluation if so

Why This Works
With the fix in place:

When evaluating ebs_block_device.*.tags.application_acronym
The function detects that the first EBS device is missing the attribute
It adds this to the missing_attributes list
The function returns an empty list
The IsNotEmpty evaluator correctly fails because there are no values
The policy now correctly enforces that all EBS block devices must have the application_acronym tag, not just some of them.