### PR TITLE
docs: add a placeholder landing page for GitHub Pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,202 @@
+<!doctype html>
+<!--
+  Placeholder landing page for Tirith. Plain HTML, no build step, no JS.
+
+  All copy is derived from README.md, which is the source of truth -- if the two
+  disagree, the README wins and this file is stale. Every prose block below is
+  wrapped in a <section> with a comment naming it, so the copy can be lifted out
+  without reading the markup.
+
+  Served by GitHub Pages. Keep it dependency-free: the repo has no site
+  generator and this page should not introduce one.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Tirith — IaC Governance plugin</title>
+<meta name="description" content="Plugin IaC Governance for any pipeline, running anywhere. Evaluate plans with Tirith, protect sensitive values, enforce centralised governance, and surface actionable results before infrastructure changes are applied.">
+<style>
+  :root {
+    --bg: #ffffff;
+    --fg: #1a1a1a;
+    --muted: #5c5c5c;
+    --rule: #e2e2e2;
+    --accent: #5a3fc0;
+    --code-bg: #f6f6f7;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #14141a;
+      --fg: #ececf1;
+      --muted: #a3a3ad;
+      --rule: #2c2c36;
+      --accent: #b3a4f5;
+      --code-bg: #1e1e26;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0 auto;
+    padding: 3rem 1.25rem 5rem;
+    max-width: 46rem;
+    background: var(--bg);
+    color: var(--fg);
+    font: 16px/1.65 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  }
+  h1 { font-size: 2rem; margin: 0 0 .5rem; letter-spacing: -.02em; }
+  h2 { font-size: 1.15rem; margin: 3rem 0 .75rem; padding-top: 1.5rem; border-top: 1px solid var(--rule); }
+  p { margin: 0 0 1rem; }
+  a { color: var(--accent); }
+  .lede { font-size: 1.1rem; color: var(--fg); }
+  .muted { color: var(--muted); }
+  code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: .875rem; }
+  pre {
+    background: var(--code-bg);
+    border: 1px solid var(--rule);
+    border-radius: 6px;
+    padding: .875rem 1rem;
+    overflow-x: auto;
+  }
+  code { background: var(--code-bg); padding: .1em .35em; border-radius: 3px; }
+  pre code { background: none; padding: 0; }
+  ul { padding-left: 1.25rem; }
+  li { margin-bottom: .6rem; }
+  .links { display: flex; flex-wrap: wrap; gap: 1.25rem; margin-top: .5rem; }
+  footer { margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--rule); color: var(--muted); font-size: .875rem; }
+</style>
+</head>
+<body>
+
+<!-- HERO -->
+<section>
+  <h1>Tirith — IaC Governance plugin</h1>
+  <p class="lede">
+    Plugin IaC Governance for any pipeline, running anywhere. Evaluate plans with Tirith, protect
+    sensitive values, enforce centralised governance, and surface actionable results before
+    infrastructure changes are applied.
+  </p>
+  <p>
+    Tirith reads the plan your pipeline already produces, checks it against your policies, and exits
+    non-zero so a violating change never reaches <code>apply</code>. Apache-2.0, and no account
+    needed.
+  </p>
+<pre><code>pip install git+https://github.com/StackGuardian/tirith.git</code></pre>
+  <p class="links">
+    <a href="https://github.com/StackGuardian/tirith">Repository</a>
+    <a href="https://github.com/StackGuardian/tirith#readme">Documentation</a>
+  </p>
+</section>
+
+<!-- THE PROBLEM -->
+<section>
+  <h2>The problem</h2>
+  <p>
+    A pipeline that runs <code>init</code>, <code>plan</code> and <code>apply</code> deploys whatever
+    the plan says. Nothing sits between the plan and the change.
+  </p>
+  <ul>
+    <li>Every repository does it its own way, so there is no one place to see what was deployed, or what was refused.</li>
+    <li>Rules that do exist live in whichever pipeline someone wrote them into, and get copied into the next repository by hand.</li>
+    <li>When a check does fail, the log says a job failed. It does not say which rule, on which resource, or what value broke it.</li>
+  </ul>
+</section>
+
+<!-- WHAT YOU ADD -->
+<section>
+  <h2>What you add</h2>
+  <p>Two lines, on GitHub Actions:</p>
+<pre><code>- run: terraform show -json tfplan &gt; plan.json
+- uses: StackGuardian/tirith-iac-governance-action@v2</code></pre>
+  <p class="muted">
+    With a <code>plan.json</code> in the working directory that is the whole integration — no
+    <code>with:</code> block. Policies are JSON files committed under
+    <code>.tirith/policies</code>.
+  </p>
+</section>
+
+<!-- WHAT YOU GET -->
+<section>
+  <h2>What you get</h2>
+  <ul>
+    <li>
+      <strong>Policies as data, not code.</strong> A rule is a JSON file describing what to look for,
+      rather than a program you have to maintain. Terraform plans, terraform state, Kubernetes
+      manifests, Infracost breakdowns and arbitrary JSON are all evaluated the same way.
+    </li>
+    <li>
+      <strong>Cost, before the change is applied.</strong> Point Tirith at an
+      <code>infracost breakdown</code> and gate on the monthly or hourly total of the resources the
+      plan would create.
+    </li>
+    <li>
+      <strong>Sensitive values masked on your own runner</strong>, before anything leaves it — so a
+      value marked <code>sensitive</code> stays out of the report and out of any upload.
+    </li>
+    <li>
+      <strong>An exit code your pipeline can act on.</strong> <code>3</code> means a policy said no;
+      <code>1</code> means Tirith could not tell you either way. A job that treats every non-zero
+      code alike cannot tell a working gate from a broken one.
+    </li>
+    <li>
+      <strong>The plan and the code, kept together.</strong> In platform mode each run uploads the
+      masked documents alongside the terraform source they describe, so a finding can still be read
+      against the code that caused it later on.
+    </li>
+    <li>
+      <strong>One policy set, many pipelines.</strong> Because Tirith is a CLI rather than an
+      integration built into one CI system, the same policies gate a GitHub Actions job, a GitLab job
+      and a laptop. In platform mode, Tirith rules and Checkov findings come back in a single
+      verdict.
+    </li>
+  </ul>
+</section>
+
+<!-- WORKS WITH -->
+<section>
+  <h2>Works with</h2>
+  <ul>
+    <li>
+      <strong>GitHub Actions</strong> — a native action that finds the plan, posts a sticky
+      pull-request comment, creates a check run and sets the exit code:
+      <a href="https://github.com/StackGuardian/tirith-iac-governance-action">tirith-iac-governance-action</a>.
+    </li>
+    <li>
+      <strong>GitLab CI, and any container-based CI</strong> — install the CLI in the job and call it
+      directly, which is all the action does underneath. There is no GitLab-native equivalent of the
+      action.
+    </li>
+    <li>
+      <strong>Your machine</strong> — the same command, the same verdict, no account and no network.
+    </li>
+    <li class="muted">
+      <strong>Azure DevOps</strong> — not supported today.
+    </li>
+  </ul>
+</section>
+
+<!-- OPTIONAL PLATFORM MODE -->
+<section>
+  <h2>Keeping policy in one place</h2>
+  <p>
+    Everything above works with policy files committed to your repository. If you would rather not
+    copy those files into every repository that needs gating,
+    <code>tirith platform check</code> evaluates against the policies a
+    <a href="https://www.stackguardian.io/">StackGuardian</a> organization enforces instead — same
+    document, same verdict, same exit codes, plus a central run history. That mode is optional, and
+    is the only part that talks to a network.
+  </p>
+</section>
+
+<footer>
+  <p class="links">
+    <a href="https://github.com/StackGuardian/tirith">GitHub</a>
+    <a href="https://github.com/StackGuardian/tirith#readme">Docs</a>
+    <a href="https://github.com/StackGuardian/tirith/blob/main/LICENSE">Apache-2.0</a>
+    <a href="https://github.com/StackGuardian/tirith/issues">Issues</a>
+  </p>
+  <p>Maintained by <a href="https://www.stackguardian.io/">StackGuardian</a>.</p>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
A placeholder landing page, living in the repo at `docs/index.html`, as a stopgap until the designer rebuilds it.

Pages is enabled on this repo but has never served anything: the `gh-pages` branch contains only `.nojekyll`, so <https://stackguardian.github.io/tirith/> currently returns **404**. This would be the first content that URL has served.

### ⚠️ Merging this does not publish it

Serving from the repo tree needs a one-time settings change, since Pages is currently pointed at the empty `gh-pages` branch:

> **Settings → Pages → Build and deployment → Source: Deploy from a branch → Branch: `main` / folder: `/docs`**

I have deliberately not made that change — it is a production setting on a public repo, and flipping it before this merges would achieve nothing anyway. Say the word and I will, or it is two clicks.

Note the sequencing: the branch selected there must be one that contains `docs/index.html`. Based on `feat/gate-capable-engine`, so if Pages is pointed at `main` the page appears when #272 lands.

`docs/.nojekyll` keeps Jekyll away from the `.md` and `.gif` files already in that folder.

### What it is

Six sections, in the order a stranger needs them: what it is and how to install it, the problem it solves, the two lines you add, what you get, what it works with, and platform mode last.

Deliberately plain — **one hand-written HTML file, no site generator, no build step, no JavaScript**, about 200 lines including roughly 50 of CSS. The repo has no site tooling and a placeholder is a poor reason to introduce some. Every prose block sits in its own commented `<section>`, so the copy can be lifted out without reading the markup. Light and dark via `prefers-color-scheme`; one column; no images, no fonts, no external requests.

### Copy

Derived from `README.md` rather than newly written, so there is one source of truth to keep correct. A comment at the top of the file says so.

Claims are limited to what I could verify in the code:

- **No OPA.** Nothing in `src/` references `opa` or `rego`, so it is absent from the page.
- **No approvals.** `counts.approval_required` exists, but `platform/cli.py` reports it as a warning that explicitly does not block — too weak to sell as a feature.
- **Checkov is scoped to platform mode**, because Tirith does not run it; `report.py` only renders findings the platform returns.
- Cost (`providers/infracost`), masking, the exit-code split and the bundle keeping documents next to `code/` are all verified against the source.

No testimonials, no logos, no metrics, no signup form.

### The `@v2` problem, again

The one example on the page uses `@v2`, which **does not exist** — the newest tag on the action is `v1.0.0-beta`. This matches both merged READMEs rather than diverging from them, so cutting that one tag makes all three surfaces correct at once. It is worth doing before this page is publicly linked, since a landing page is the first thing a stranger copy-pastes.
