### PR TITLE
docs: announce the interface on the landing page, and fix the install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
 >
 > Explore a failing evaluation down to the resource that caused it, assemble policies from a
 > form, and experiment in a playground with worked examples. Try it with
-> `pip install 'py-tirith[tui]'` and then `tirith ui` — see
+> `pip install 'py-tirith[tui] @ git+https://github.com/StackGuardian/tirith.git'`, then
+> `tirith ui` — see
 > [The interactive interface](#the-interactive-interface).
 >
 > It is new, so the rough edges are still being found. Tell us what is confusing, what is
@@ -235,8 +236,11 @@ nobody gating a pipeline should pay to install an interface they never open. It 
 3.9 or newer, while tirith itself still supports 3.8:
 
 ```bash
-pip install 'py-tirith[tui]'
+pip install 'py-tirith[tui] @ git+https://github.com/StackGuardian/tirith.git'
 ```
+
+Tirith is not on PyPI — `pip install py-tirith` finds nothing and `pip install tirith` installs an
+unrelated project of the same name — so the extra is requested against the git URL.
 
 ```bash
 tirith ui                                          # playground, with worked examples

--- a/documentation/docs/getting-started-with-tirith.md
+++ b/documentation/docs/getting-started-with-tirith.md
@@ -15,8 +15,9 @@ import TabItem from '@theme/TabItem';
 :::note New — `tirith ui`, an interactive interface. In beta, and we want your input.
 
 Explore a failing evaluation down to the resource that caused it, assemble policies from a form, and
-experiment in a playground with worked examples. Install it with `pip install 'py-tirith[tui]'` and
-run `tirith ui` — see
+experiment in a playground with worked examples. Install it with
+`pip install 'py-tirith[tui] @ git+https://github.com/StackGuardian/tirith.git'` and run
+`tirith ui` — see
 [the interactive interface](tirith-usage/interactive-interface.md).
 
 It is new, so the rough edges are still being found. Tell us what is confusing, what is missing, or

--- a/documentation/docs/tirith-usage/interactive-interface.md
+++ b/documentation/docs/tirith-usage/interactive-interface.md
@@ -33,8 +33,11 @@ pipeline should pay to install an interface they never open. It needs Python 3.9
 Tirith itself still supports 3.8.
 
 ```bash
-pip install 'py-tirith[tui]'
+pip install 'py-tirith[tui] @ git+https://github.com/StackGuardian/tirith.git'
 ```
+
+Tirith is not on PyPI — `pip install py-tirith` finds nothing and `pip install tirith` installs an
+unrelated project of the same name — so the extra is requested against the git URL.
 
 ## Opening it
 

--- a/documentation/src/pages/index.js
+++ b/documentation/src/pages/index.js
@@ -28,6 +28,17 @@ const content = {
       'Tirith reads the plan your pipeline already produces, checks it against your policies, and ' +
       'exits non-zero so a violating change never reaches apply. Apache-2.0, and no account needed.',
     install: 'pip install git+https://github.com/StackGuardian/tirith.git',
+    announcement: {
+      label: 'New',
+      // No backticks: this is plain JSX text, not markdown, so they would render literally.
+      // The command is set in <code> by the renderer instead.
+      command: 'tirith ui',
+      text:
+        '— an interactive interface. Explore a failing evaluation down to the resource that ' +
+        'caused it, build policies from a form, and experiment in a playground.',
+      to: '/docs/tirith-usage/interactive-interface/',
+      linkLabel: 'Read more',
+    },
     actions: [
       {label: 'Get started', to: '/docs/getting-started-with-tirith/', primary: true},
       {label: 'GitHub', href: 'https://github.com/StackGuardian/tirith'},
@@ -167,9 +178,16 @@ function Action({label, to, href, primary}) {
 }
 
 function Hero() {
-  const {title, tagline, body, install, actions} = content.hero;
+  const {title, tagline, body, install, actions, announcement} = content.hero;
   return (
     <header className={styles.hero}>
+      <Link className={styles.announcement} to={announcement.to}>
+        <span className={styles.announcementLabel}>{announcement.label}</span>
+        <span>
+          <code>{announcement.command}</code> {announcement.text}
+        </span>
+        <span className={styles.announcementLink}>{announcement.linkLabel} →</span>
+      </Link>
       <Heading as="h1" className={styles.heroTitle}>
         {title}
       </Heading>

--- a/documentation/src/pages/index.module.css
+++ b/documentation/src/pages/index.module.css
@@ -81,3 +81,49 @@
     font-size: 1.75rem;
   }
 }
+
+/*
+ * The announcement strip above the hero title. A link rather than a static banner: the whole
+ * row is the target, since a one-line notice about a new feature is only useful if it is also
+ * the way to reach it.
+ *
+ * Colours come from Infima's own variables so it follows the site's light and dark themes
+ * rather than pinning a background that only works in one of them.
+ */
+.announcement {
+  display: inline-flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+  padding: 0.5rem 0.9rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 2rem;
+  background: var(--ifm-color-emphasis-100);
+  color: var(--ifm-font-color-base);
+  font-size: 0.95rem;
+  line-height: 1.5;
+  text-decoration: none;
+}
+
+.announcement:hover {
+  border-color: var(--ifm-color-primary);
+  text-decoration: none;
+}
+
+.announcementLabel {
+  padding: 0.05rem 0.5rem;
+  border-radius: 1rem;
+  background: #006ee6;
+  color: #fff;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.announcementLink {
+  color: var(--ifm-color-primary);
+  font-weight: 600;
+  white-space: nowrap;
+}

--- a/src/tirith/tui/__init__.py
+++ b/src/tirith/tui/__init__.py
@@ -13,7 +13,7 @@ run() rather than here, so that:
 
 TUI_EXTRA_HINT = (
     "The Tirith interactive interface needs the optional 'tui' extra:\n"
-    "    pip install 'py-tirith[tui]'\n"
+    "    pip install 'py-tirith[tui] @ git+https://github.com/StackGuardian/tirith.git'\n"
     "It is optional so that using tirith as a CI gate stays dependency-light. It needs "
     "Python 3.9 or newer; tirith itself supports 3.8."
 )

--- a/src/tirith/tui/cli.py
+++ b/src/tirith/tui/cli.py
@@ -221,7 +221,8 @@ def _serve(opts, has_result):
         if not _is_missing_toolkit(e):
             raise
         print(
-            "Serving needs the optional 'tui' extra:\n    pip install 'py-tirith[tui]'",
+            "Serving needs the optional 'tui' extra:\n"
+            "    pip install 'py-tirith[tui] @ git+https://github.com/StackGuardian/tirith.git'",
             file=sys.stderr,
         )
         return ExitStatus.ERROR


### PR DESCRIPTION
Follow-up to #280. Two things, both about someone arriving at the project for the first time.

## The landing page said nothing about `tirith ui`

#280 covered the getting-started page and added a reference page, but the site's front page is not markdown — it is `documentation/src/pages/index.js`, a React page with its own content object — so the first thing a visitor sees was unchanged.

Adds a clickable strip above the hero: a **New** pill, one line on what the interface does, and a link through to the reference page. The whole row is the link, since a notice about a new feature is only useful if it is also the way to reach it.

Styled from Infima's own variables so it follows the site's light and dark themes rather than pinning colours that work in one of them, and the command is set in a `<code>` element rather than backticks — this is JSX, where backticks render literally.

## The install command did not work

Every place the interface is documented said:

```bash
pip install 'py-tirith[tui]'
```

**Tirith is not published to PyPI.** `py-tirith` 404s there, and `pip install tirith` fetches an unrelated project of the same name — something the README already warned about a hundred lines further down. So the one command a reader was told to run could not succeed for anyone.

Replaced in all five user-facing places — the README callout, the README section, the docs reference page, the docs landing note, and the two hints the program itself prints when the extra is missing — with the form that requests the extra against the git URL:

```bash
pip install 'py-tirith[tui] @ git+https://github.com/StackGuardian/tirith.git'
```

Confirmed by installing it into a clean environment: textual 8.2.8 and textual-serve both resolve, and `tirith ui` runs. The README and the reference page now also say *why* the git URL is needed, next to the command rather than far from it.

## Verification

- `npm run build` on the docs site is clean, and the banner renders with a working link to `/docs/tirith-usage/interactive-interface/`
- 764 tests passing, `black --check` clean across 108 files
- Both runtime hints checked by running them

If Tirith is ever published to PyPI, the plain `pip install 'py-tirith[tui]'` becomes correct and these can be simplified back.
