### PR TITLE
fix: avoid mutable default arguments and use identity check for type comparison

### DIFF
--- a/src/tirith/core/core.py
+++ b/src/tirith/core/core.py
@@ -245,7 +245,7 @@ def final_evaluator(eval_string: str, eval_id_values: Dict[str, Optional[bool]])
 
 
 def start_policy_evaluation(
-    policy_path: str, input_path: str, var_paths: List[str] = [], inline_vars: List[str] = []
+    policy_path: str, input_path: str, var_paths: Optional[List[str]] = None, inline_vars: Optional[List[str]] = None
 ) -> Dict:
     """
     Start Tirith policy evaluation from policy file, input file, and optional variable files.
@@ -255,6 +255,8 @@ def start_policy_evaluation(
     :param var_paths: List of paths to the variable files
     :return: Policy evaluation result
     """
+    var_paths = var_paths or []
+    inline_vars = inline_vars or []
     with open(policy_path) as f:
         policy_data = json.load(f)
     # TODO: validate policy_data against schema
@@ -304,8 +306,8 @@ def _merge_var_dicts(var_dicts: List[dict]) -> dict:
     return merged_var_dict
 
 
-def start_policy_evaluation_from_dict(policy_dict: Dict, input_dict: Dict, var_dict: Dict = {}) -> Dict:
-    policy_dict, not_found_vars = get_policy_with_vars_replaced(policy_dict, var_dict)
+def start_policy_evaluation_from_dict(policy_dict: Dict, input_dict: Dict, var_dict: Optional[Dict] = None) -> Dict:
+    policy_dict, not_found_vars = get_policy_with_vars_replaced(policy_dict, var_dict or {})
     if not_found_vars:
         return {"errors": [f"Variables not found: {', '.join(not_found_vars)}"]}
 

--- a/src/tirith/core/evaluators/regex_match.py
+++ b/src/tirith/core/evaluators/regex_match.py
@@ -9,7 +9,7 @@ class RegexMatch(BaseEvaluator):
         evaluation_result = {"passed": False, "message": "Not evaluated"}
         try:
             match = 0
-            if type(evaluator_input) in (str, list, dict) and type(evaluator_data) == str:
+            if type(evaluator_input) in (str, list, dict) and type(evaluator_data) is str:
                 evaluator_input = str(evaluator_input)
                 match = re.search(evaluator_data, evaluator_input)
                 if match is None:


### PR DESCRIPTION
## Summary

Three small correctness fixes flagged by ruff (B006 / E721):

1. **`src/tirith/core/core.py`** — `start_policy_evaluation(var_paths: List[str] = [], inline_vars: List[str] = [])` and `start_policy_evaluation_from_dict(var_dict: Dict = {})` used mutable default arguments. Python evaluates defaults once at definition time, so the same list/dict object is shared across every call — a latent state-leak footgun, especially for `var_dict`, which is passed into `get_policy_with_vars_replaced()`. Changed to the `Optional[...] = None` sentinel pattern with normalization at the top of each function; behavior is unchanged for all existing callers.

2. **`src/tirith/core/evaluators/regex_match.py`** — `type(evaluator_data) == str` compares type objects with `==`; identity (`is str`) is the intended semantics and is what newer linters (ruff E721) require.

## Testing
`python -m py_compile` passes on both files and `ruff check --select B006,E721` is clean after the change. No functional change for existing callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)