### PR TITLE
chore: drop the unreachable ERROR_TIMEOUT exit code

### DIFF
--- a/src/tirith/status.py
+++ b/src/tirith/status.py
@@ -7,7 +7,11 @@ class ExitStatus(IntEnum):
 
     SUCCESS = 0
     ERROR = 1
-    ERROR_TIMEOUT = 2
+
+    # 2 is deliberately absent. It used to be ERROR_TIMEOUT, but nothing ever returned it -- a
+    # timeout is caught alongside URLError in the client and reported as ERROR. Meanwhile argparse
+    # already exits 2 of its own accord on a usage error, so a caller seeing 2 has passed a bad
+    # argument, not waited too long. Reclaiming it would make those two indistinguishable.
 
     # A policy said no, under `--fail-on-error`. Distinct from ERROR so a caller can
     # tell "your infrastructure violates a policy" from "tirith could not reach the platform" --


### PR DESCRIPTION
`ERROR_TIMEOUT = 2` was declared and never returned. It appears exactly once in the tree — on its own
definition line — and `grep` finds no other reference in `src/`, `tests/`, or `documentation/`.

A real timeout does not produce it. `TimeoutError` is caught alongside `URLError` in the client
(`platform/client.py:140`, `:313`) and reported as `ERROR`, so the code the enum promised was never
the code a caller got.

## Worse than dead

`2` does occur in practice — argparse exits 2 on any usage error:

```
$ tirith platform check --region nonsense
$ echo $?
2
```

So the value was already spoken for, and it meant the opposite of what the enum claimed. Anyone
branching on *"2 means it timed out"* was wrong twice over: real timeouts give **1**, and a **2** means
their arguments were malformed — which retrying will never fix.

Removing the constant makes the ladder honest:

| code | meaning |
|---|---|
| `0` | passed, warned, or no policies in scope |
| `1` | tool failure — unreachable platform, no verdict, timeout, half a credential |
| `2` | argparse rejected the arguments (not ours to assign) |
| `3` | a policy failed, under `--fail-on-error` |
| `130` | interrupted |

A comment is left where the constant was, so `2` is not reclaimed later — doing so would make a
timeout and a malformed argument indistinguishable again.

## Checks

- Nothing referenced it: no other occurrence in this repo, and downstream is clean too — the GitHub
  Action's README mentions `timeout` only as the unrelated input ("Seconds to wait for the run"), and
  the GitLab component has no reference.
- `@unique` still holds; `SUCCESS`/`ERROR`/`ERROR_POLICY_FAILED`/`ERROR_CTRL_C` keep their values.
- Test suite: **12 failed, 687 passed, 10 skipped** — byte-identical to the same run on unmodified
  `main`, so this change introduces no failures. Those 12 are pre-existing (11 fixture
  `FileNotFoundError`s under `tests/providers/terraform_plan/`, plus
  `test_readme_is_current.py::test_the_usage_block_lists_every_option_the_cli_accepts`, which looks
  like genuine README drift and is worth its own issue).
