### PR TITLE
Show attribute-level changes in the plan diff

### DIFF
--- a/src/tirith/plan_actions.py
+++ b/src/tirith/plan_actions.py
@@ -6,6 +6,8 @@ pull-request comment. Keeping one implementation is what stops them disagreeing 
 `["delete", "create"]` is a replacement or two separate operations.
 """
 
+import json
+
 # What terraform calls the operation, keyed by the exact action tuple it reports.
 #
 # The replacement pair is ordered, and which way round it is changes the risk rather than the
@@ -99,3 +101,112 @@ def summary_line(counts):
     if counts.get("replace"):
         parts.append(f"{counts['replace']} to replace")
     return "Plan: " + ", ".join(parts) + "."
+
+
+# Rendered in place of a value we must not or cannot print. Both are terraform's own wording, so a
+# reader who knows plan output needs no translation.
+SENSITIVE = "(sensitive value)"
+UNKNOWN = "(known after apply)"
+
+
+def _contains_true(node):
+    """
+    Whether a sensitivity or unknown-ness tree marks anything at all.
+
+    These trees mirror the *shape* of the value rather than being booleans: terraform reports
+    `{"triggers_replace": [false]}`, where the list is structure and the `false` is the answer. A
+    truthy test on the node therefore says "sensitive" for a list that says the opposite -- which is
+    how a first attempt printed "(sensitive value)" over a value that was never secret.
+
+    Any `True` anywhere means the whole value is treated as marked. That is deliberately
+    conservative: for sensitivity it over-hides rather than leaks, and for unknown-ness it prefers
+    "we cannot show this" to printing half a value as if it were whole.
+    """
+    if node is True:
+        return True
+    if isinstance(node, dict):
+        return any(_contains_true(v) for v in node.values())
+    if isinstance(node, list):
+        return any(_contains_true(v) for v in node)
+    return False
+
+
+def attribute_changes(change, limit=8):
+    """
+    Per-attribute changes for one resource, as (marker, key, before, after, forces_replacement).
+
+    `before` and `after` are already rendered to strings here, because whether a value may be shown
+    at all is plan semantics -- sensitivity and unknown-ness live in the document -- while *how* to
+    make a string safe for the surface it lands on belongs to the renderer.
+
+    What each action shows, and why it differs:
+
+      create   every attribute with a known value. The unknown ones are what terraform fills in, and
+               a wall of "(known after apply)" says nothing a reader can act on, so they are counted.
+      update   only what changed. That is the whole question being asked.
+      replace  the same, plus which attribute forced it -- the most useful line in a plan review.
+      delete   nothing. The resource is going away; its former values neither inform the decision nor
+               belong in a public comment.
+    """
+    actions = tuple(a for a in ((change or {}).get("actions") or []) if a)
+    if not actions or actions == ("no-op",) or actions == ("delete",):
+        return [], 0, 0
+
+    before = (change.get("before") or {}) if isinstance(change.get("before"), dict) else {}
+    after = (change.get("after") or {}) if isinstance(change.get("after"), dict) else {}
+    unknown = change.get("after_unknown") or {}
+    after_sensitive = change.get("after_sensitive")
+    after_sensitive = after_sensitive if isinstance(after_sensitive, dict) else {}
+    before_sensitive = change.get("before_sensitive")
+    before_sensitive = before_sensitive if isinstance(before_sensitive, dict) else {}
+    forces = {path[0] for path in (change.get("replace_paths") or []) if path}
+
+    creating = actions == ("create",)
+    rows = []
+    hidden_unknown = 0
+
+    for key in sorted(set(before) | set(after) | (set(unknown) if isinstance(unknown, dict) else set())):
+        node = unknown.get(key) if isinstance(unknown, dict) else None
+        is_unknown = _contains_true(node)
+        old, new = before.get(key), after.get(key)
+
+        if not is_unknown and old == new:
+            continue
+
+        if creating:
+            if is_unknown:
+                # Counted rather than printed: on a create these are every computed attribute, and
+                # naming them crowds out the values the author actually chose.
+                hidden_unknown += 1
+                continue
+            rows.append(("+", key, None, _render_value(new, after_sensitive.get(key)), key in forces))
+            continue
+
+        rows.append(
+            (
+                "~",
+                key,
+                _render_value(old, before_sensitive.get(key)),
+                UNKNOWN if is_unknown else _render_value(new, after_sensitive.get(key)),
+                key in forces,
+            )
+        )
+
+    dropped = max(0, len(rows) - limit)
+    return rows[:limit], dropped, hidden_unknown
+
+
+def _render_value(value, sensitivity_node):
+    if _contains_true(sensitivity_node):
+        return SENSITIVE
+    if value is None:
+        return "null"
+    if isinstance(value, str):
+        return f'"{value}"'
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    # Nested structures are compacted rather than rendered as a tree. A full nested diff is a much
+    # larger feature, and a compact form still answers "did this change and roughly to what".
+    return json.dumps(value, separators=(",", ":"), sort_keys=True)

--- a/src/tirith/platform/report.py
+++ b/src/tirith/platform/report.py
@@ -30,9 +30,10 @@ _ICONS = {FAIL: "❌", WARN: "⚠️", APPROVAL_REQUIRED: "⏳", PASS: "✅", UN
 # readable without a click; large ones must not push the findings off the screen.
 PLAN_INLINE_LIMIT = 12
 
-# A hard cap on rows, independent of the comment limit. A thousand-resource plan would otherwise
-# consume the whole budget and take the findings down with it during truncation.
-PLAN_ROW_LIMIT = 50
+# A hard cap on lines, independent of the comment limit. A thousand-resource plan would otherwise
+# consume the whole budget and take the findings down with it during truncation. Counted in lines
+# rather than resources because each resource now brings its changed attributes with it.
+PLAN_LINE_LIMIT = 60
 
 
 def _fence_safe(value):
@@ -56,6 +57,40 @@ def _fence_safe(value):
     return text
 
 
+def _render_attributes(change):
+    """
+    The per-attribute lines under one resource row.
+
+    Every key and every value goes through `_fence_safe`, and that is the whole reason this is a
+    separate function rather than an f-string at the call site. An attribute *value* is as
+    author-controlled as an address -- more so, since it is the literal text of their terraform -- and
+    a first version of this passed values through raw. A value of "```" closed the block and let the
+    rest of the comment render as markdown, reopening exactly the hole the address guard was written
+    to close. The guard belongs on both or it protects neither.
+    """
+    rows, dropped, hidden_unknown = plan_actions.attribute_changes(change)
+
+    lines = []
+    for marker, key, before, after, forces in rows:
+        rendered_key = _fence_safe(key)
+        if before is None:
+            line = f"    {marker} {rendered_key} = {_fence_safe(after)}"
+        else:
+            line = f"    {marker} {rendered_key} = {_fence_safe(before)} -> {_fence_safe(after)}"
+        if forces:
+            # Terraform's own wording, and the most consequential thing on the row: it names the one
+            # attribute whose change is costing a destroy and recreate.
+            line += "   # forces replacement"
+        lines.append(line)
+
+    trailer = []
+    if dropped:
+        trailer.append(f"    … and {dropped} more changed attribute(s)")
+    if hidden_unknown:
+        trailer.append(f"    … and {hidden_unknown} computed attribute(s), known after apply")
+    return lines + trailer
+
+
 def render_plan_block(plan):
     """
     The planned changes, as a diff-fenced list plus terraform's summary line.
@@ -77,6 +112,7 @@ def render_plan_block(plan):
     counts = plan_actions.plan_counts(changes)
 
     rows = []
+    listed_resources = 0
     for change in changes:
         if not isinstance(change, dict):
             continue
@@ -90,11 +126,16 @@ def render_plan_block(plan):
         if not address:
             continue
         rows.append(f"{marker} {address:<48} {_fence_safe(plan_actions.action_summary(actions))}".rstrip())
+        rows.extend(_render_attributes(change.get("change") or {}))
+        listed_resources += 1
 
-    dropped = 0
-    if len(rows) > PLAN_ROW_LIMIT:
-        dropped = len(rows) - PLAN_ROW_LIMIT
-        rows = rows[:PLAN_ROW_LIMIT]
+    # The caps count *lines*, not resources, now that a resource brings its attributes with it. A
+    # ten-resource plan can be eighty lines, and it is the line count that decides whether the
+    # comment is readable.
+    dropped_lines = 0
+    if len(rows) > PLAN_LINE_LIMIT:
+        dropped_lines = len(rows) - PLAN_LINE_LIMIT
+        rows = rows[:PLAN_LINE_LIMIT]
 
     summary = plan_actions.summary_line(counts)
     if counts.get("no_op"):
@@ -109,11 +150,13 @@ def render_plan_block(plan):
         # having, otherwise the comment looks like it simply forgot to mention the plan.
         return [summary, ""]
 
-    fence = ["```diff"] + rows + (["", f"… and {dropped} more"] if dropped else []) + ["```"]
+    truncation = ["", f"… and {dropped_lines} more line(s), truncated"] if dropped_lines else []
+    fence = ["```diff"] + rows + truncation + ["```"]
 
     if len(rows) > PLAN_INLINE_LIMIT:
+        noun = "resource" if listed_resources == 1 else "resources"
         block = [
-            f"<details><summary>Show plan — {len(rows)} changed resources</summary>",
+            f"<details><summary>Show plan — {listed_resources} changed {noun}</summary>",
             "",
         ] + fence + ["", "</details>"]
     else:

--- a/src/tirith/platform/report.py
+++ b/src/tirith/platform/report.py
@@ -26,13 +26,13 @@ COMMENT_LIMIT = 60000
 
 _ICONS = {FAIL: "❌", WARN: "⚠️", APPROVAL_REQUIRED: "⏳", PASS: "✅", UNKNOWN: "❓"}
 
-# How many changed resources render inline before the block is collapsed. Small changes should be
-# readable without a click; large ones must not push the findings off the screen.
-PLAN_INLINE_LIMIT = 12
-
 # A hard cap on lines, independent of the comment limit. A thousand-resource plan would otherwise
 # consume the whole budget and take the findings down with it during truncation. Counted in lines
-# rather than resources because each resource now brings its changed attributes with it.
+# rather than resources because each resource brings its changed attributes with it.
+#
+# The block is never collapsed behind a <details>. It was, above twelve resources -- but the plan is
+# the thing the comment was extended to show, and putting it behind a click means the common case is
+# a reviewer who never sees it. What gives way under this cap is detail, not visibility.
 PLAN_LINE_LIMIT = 60
 
 
@@ -111,8 +111,7 @@ def render_plan_block(plan):
 
     counts = plan_actions.plan_counts(changes)
 
-    rows = []
-    listed_resources = 0
+    entries = []
     for change in changes:
         if not isinstance(change, dict):
             continue
@@ -125,17 +124,11 @@ def render_plan_block(plan):
         address = _fence_safe(change.get("address") or change.get("type") or "")
         if not address:
             continue
-        rows.append(f"{marker} {address:<48} {_fence_safe(plan_actions.action_summary(actions))}".rstrip())
-        rows.extend(_render_attributes(change.get("change") or {}))
-        listed_resources += 1
+        row = f"{marker} {address:<48} {_fence_safe(plan_actions.action_summary(actions))}".rstrip()
+        entries.append((row, _render_attributes(change.get("change") or {})))
 
-    # The caps count *lines*, not resources, now that a resource brings its attributes with it. A
-    # ten-resource plan can be eighty lines, and it is the line count that decides whether the
-    # comment is readable.
-    dropped_lines = 0
-    if len(rows) > PLAN_LINE_LIMIT:
-        dropped_lines = len(rows) - PLAN_LINE_LIMIT
-        rows = rows[:PLAN_LINE_LIMIT]
+    listed_resources = len(entries)
+    rows, hidden_detail, dropped_resources = _fit_plan_rows(entries)
 
     summary = plan_actions.summary_line(counts)
     if counts.get("no_op"):
@@ -150,19 +143,41 @@ def render_plan_block(plan):
         # having, otherwise the comment looks like it simply forgot to mention the plan.
         return [summary, ""]
 
-    truncation = ["", f"… and {dropped_lines} more line(s), truncated"] if dropped_lines else []
-    fence = ["```diff"] + rows + truncation + ["```"]
+    notes = []
+    if hidden_detail:
+        notes += ["", f"… attribute detail omitted: {hidden_detail} more line(s) than a comment can carry"]
+    if dropped_resources:
+        notes += ["", f"… and {dropped_resources} more resource(s), truncated"]
 
-    if len(rows) > PLAN_INLINE_LIMIT:
-        noun = "resource" if listed_resources == 1 else "resources"
-        block = [
-            f"<details><summary>Show plan — {listed_resources} changed {noun}</summary>",
-            "",
-        ] + fence + ["", "</details>"]
-    else:
-        block = fence
+    return ["```diff"] + rows + notes + ["```", "", summary, ""]
 
-    return block + ["", summary, ""]
+
+def _fit_plan_rows(entries):
+    """
+    Fit the plan into PLAN_LINE_LIMIT lines, giving up detail before resources.
+
+    Returns (rows, hidden_detail_lines, dropped_resources).
+
+    The order of sacrifice is the whole point. A resource row says *what is happening to your
+    infrastructure*; an attribute row elaborates on one. So an oversized plan loses every attribute
+    row before it loses a single resource, and only a resource list that is still too long after that
+    gets cut off the end.
+
+    Detail is dropped wholesale rather than from the cut-off point onward. Trimming at the boundary
+    would annotate the first handful of resources and leave the rest bare, which reads as though the
+    later ones had nothing to say -- the most misleading shape available, since the untouched-looking
+    ones are exactly where a reviewer stops looking.
+    """
+    full = [line for row, attributes in entries for line in [row] + attributes]
+    if len(full) <= PLAN_LINE_LIMIT:
+        return full, 0, 0
+
+    bare = [row for row, _ in entries]
+    hidden_detail = len(full) - len(bare)
+    if len(bare) <= PLAN_LINE_LIMIT:
+        return bare, hidden_detail, 0
+
+    return bare[:PLAN_LINE_LIMIT], hidden_detail, len(bare) - PLAN_LINE_LIMIT
 
 
 

--- a/tests/platform/test_report_plan_attributes.py
+++ b/tests/platform/test_report_plan_attributes.py
@@ -1,0 +1,263 @@
+"""
+Attribute-level detail in the plan block.
+
+Two of these matter more than the rest. `test_an_attribute_value_cannot_escape_the_fence` covers the
+hole this feature opens -- a first draft passed values through raw and a value of "```" closed the
+block. `test_a_sensitive_value_is_never_printed` covers the one where a bug leaks rather than merely
+looks wrong.
+"""
+
+from tirith import plan_actions
+from tirith.platform import report
+
+
+def _render(changes):
+    return report.render_markdown(
+        {}, "COMPLETED", "https://example.invalid/run", plan={"resource_changes": changes}
+    )
+
+
+def _fence(body):
+    return body.split("```diff")[1].split("```")[0]
+
+
+# --- what a reviewer sees ---------------------------------------------------------------------
+
+
+def test_an_update_shows_only_what_changed():
+    body = _render(
+        [
+            {
+                "address": "terraform_data.x",
+                "type": "terraform_data",
+                "change": {
+                    "actions": ["update"],
+                    "before": {"input": "before", "untouched": "same"},
+                    "after": {"input": "after", "untouched": "same"},
+                },
+            }
+        ]
+    )
+    fence = _fence(body)
+    assert '~ input = "before" -> "after"' in fence
+    assert "untouched" not in fence
+
+
+def test_a_create_shows_known_values_and_counts_the_computed_ones():
+    """
+    A wall of "(known after apply)" tells a reader nothing they can act on, so those are counted
+    while the values the author actually chose are named.
+    """
+    body = _render(
+        [
+            {
+                "address": "aws_s3_bucket.b",
+                "type": "aws_s3_bucket",
+                "change": {
+                    "actions": ["create"],
+                    "before": None,
+                    "after": {"bucket": "demo-x"},
+                    "after_unknown": {"arn": True, "id": True},
+                },
+            }
+        ]
+    )
+    fence = _fence(body)
+    assert '+ bucket = "demo-x"' in fence
+    assert "arn" not in fence
+    assert "2 computed attribute(s), known after apply" in fence
+
+
+def test_a_destroy_lists_no_attributes():
+    """
+    The resource is going away. Its former values do not inform the decision, and printing them puts
+    the old state of a public comment's worth of infrastructure into the comment.
+    """
+    body = _render(
+        [
+            {
+                "address": "aws_db_instance.old",
+                "type": "aws_db_instance",
+                "change": {"actions": ["delete"], "before": {"password": "hunter2"}, "after": None},
+            }
+        ]
+    )
+    fence = _fence(body)
+    assert "- aws_db_instance.old" in fence
+    assert "hunter2" not in fence
+    assert "password" not in fence
+
+
+def test_the_attribute_that_forces_a_replacement_is_named():
+    """The most consequential line in a plan review: which change is costing a destroy."""
+    body = _render(
+        [
+            {
+                "address": "terraform_data.r",
+                "type": "terraform_data",
+                "change": {
+                    "actions": ["delete", "create"],
+                    "before": {"triggers_replace": ["v1"], "input": "same"},
+                    "after": {"triggers_replace": ["v2"], "input": "same"},
+                    "replace_paths": [["triggers_replace"]],
+                },
+            }
+        ]
+    )
+    fence = _fence(body)
+    assert "# forces replacement" in fence
+    assert [line for line in fence.splitlines() if "forces replacement" in line][0].lstrip().startswith(
+        "~ triggers_replace"
+    )
+
+
+# --- sensitivity, where a bug leaks -----------------------------------------------------------
+
+
+def test_a_sensitive_value_is_never_printed():
+    body = _render(
+        [
+            {
+                "address": "aws_db_instance.main",
+                "type": "aws_db_instance",
+                "change": {
+                    "actions": ["update"],
+                    "before": {"password": "hunter2"},
+                    "after": {"password": "hunter3"},
+                    "before_sensitive": {"password": True},
+                    "after_sensitive": {"password": True},
+                },
+            }
+        ]
+    )
+    fence = _fence(body)
+    assert "hunter2" not in fence and "hunter3" not in fence
+    assert "(sensitive value)" in fence
+
+
+def test_a_shape_shaped_sensitivity_tree_is_not_read_as_true():
+    """
+    terraform reports sensitivity as a tree mirroring the value, not a boolean:
+    {"triggers_replace": [false]} means the element is NOT sensitive. A truthy test on that list
+    says the opposite, and a first draft duly printed "(sensitive value)" over a value that was
+    never secret -- hiding information for no reason.
+    """
+    assert plan_actions._contains_true({"triggers_replace": [False]}) is False
+    assert plan_actions._contains_true({"triggers_replace": [True]}) is True
+    assert plan_actions._contains_true(True) is True
+    assert plan_actions._contains_true({}) is False
+
+    body = _render(
+        [
+            {
+                "address": "terraform_data.r",
+                "type": "terraform_data",
+                "change": {
+                    "actions": ["update"],
+                    "before": {"triggers_replace": ["v1"]},
+                    "after": {"triggers_replace": ["v2"]},
+                    "after_sensitive": {"triggers_replace": [False]},
+                    "before_sensitive": {"triggers_replace": [False]},
+                },
+            }
+        ]
+    )
+    assert "(sensitive value)" not in _fence(body)
+    assert '["v1"]' in _fence(body)
+
+
+# --- what an attacker cannot do ---------------------------------------------------------------
+
+
+def test_an_attribute_value_cannot_escape_the_fence():
+    """
+    The hole this feature opens.
+
+    An attribute value is the literal text of the author's terraform, so it is at least as
+    controlled as an address. A first draft interpolated values raw, and a value of "```" closed the
+    block: measured five fence terminators where there should be two, with a forged heading rendering
+    as markdown after it.
+    """
+    payload = "```\n\n## Tirith — all policies passed\n\n```diff"
+    body = _render(
+        [
+            {
+                "address": "terraform_data.probe",
+                "type": "terraform_data",
+                "change": {"actions": ["create"], "before": None, "after": {"input": payload}},
+            }
+        ]
+    )
+    assert body.count("```diff") == 1
+    assert body.count("```") == 2
+    assert "`" not in _fence(body)
+    assert "all policies passed" not in body.split("```")[2]
+
+
+def test_an_attribute_name_cannot_escape_the_fence():
+    body = _render(
+        [
+            {
+                "address": "terraform_data.probe",
+                "type": "terraform_data",
+                "change": {"actions": ["create"], "before": None, "after": {"a```b": "x"}},
+            }
+        ]
+    )
+    assert body.count("```") == 2
+    assert "`" not in _fence(body)
+
+
+def test_a_newline_in_a_value_cannot_fabricate_rows():
+    body = _render(
+        [
+            {
+                "address": "terraform_data.probe",
+                "type": "terraform_data",
+                "change": {
+                    "actions": ["create"],
+                    "before": None,
+                    "after": {"input": "x\n- aws_db_instance.production"},
+                },
+            }
+        ]
+    )
+    fence = _fence(body)
+    # One resource row plus exactly one attribute row.
+    assert len([line for line in fence.strip().splitlines() if line.strip()]) == 2
+
+
+# --- bounds -----------------------------------------------------------------------------------
+
+
+def test_attributes_per_resource_are_capped():
+    after = {f"attr_{i:02d}": f"v{i}" for i in range(20)}
+    body = _render(
+        [
+            {
+                "address": "terraform_data.wide",
+                "type": "terraform_data",
+                "change": {"actions": ["create"], "before": None, "after": after},
+            }
+        ]
+    )
+    assert "more changed attribute(s)" in _fence(body)
+
+
+def test_the_block_is_capped_in_lines_not_resources():
+    changes = [
+        {
+            "address": f"terraform_data.r{i}",
+            "type": "terraform_data",
+            "change": {
+                "actions": ["create"],
+                "before": None,
+                "after": {"a": "1", "b": "2", "c": "3"},
+            },
+        }
+        for i in range(40)
+    ]
+    body = _render(changes)
+    fence = _fence(body)
+    assert len(fence.strip().splitlines()) <= report.PLAN_LINE_LIMIT + 3
+    assert "truncated" in fence

--- a/tests/platform/test_report_plan_attributes.py
+++ b/tests/platform/test_report_plan_attributes.py
@@ -260,4 +260,6 @@ def test_the_block_is_capped_in_lines_not_resources():
     body = _render(changes)
     fence = _fence(body)
     assert len(fence.strip().splitlines()) <= report.PLAN_LINE_LIMIT + 3
-    assert "truncated" in fence
+    # 40 resources fit; 40 resources plus three attributes each do not. The detail is what gives way.
+    assert "attribute detail omitted" in fence
+    assert "terraform_data.r39" in fence

--- a/tests/platform/test_report_plan_block.py
+++ b/tests/platform/test_report_plan_block.py
@@ -106,23 +106,68 @@ def test_a_document_with_no_resource_changes_renders_no_block():
     assert "```diff" not in _render(None)
 
 
-def test_small_plans_are_inline_and_large_ones_collapse():
-    small = _plan(*[_change(f"aws_s3_bucket.b{i}", ["create"]) for i in range(report.PLAN_INLINE_LIMIT)])
-    assert "<details><summary>Show plan" not in _render(small)
-
-    large = _plan(*[_change(f"aws_s3_bucket.b{i}", ["create"]) for i in range(report.PLAN_INLINE_LIMIT + 1)])
-    assert "<details><summary>Show plan" in _render(large)
-
-
-def test_the_block_is_capped():
+def test_the_plan_is_never_collapsed():
     """
-    Capped in lines rather than resources, because a resource now brings its changed attributes with
-    it and it is the line count that decides whether the comment is readable.
+    The plan is the thing this block was added to show. Hiding it behind a click makes the common
+    case a reviewer who never opens it, which is the same as not rendering it at all.
     """
+    large = _plan(*[_change(f"aws_s3_bucket.b{i}", ["create"]) for i in range(40)])
+    body = _render(large)
+    assert "<details><summary>Show plan" not in body
+    assert "```diff" in body
+    assert "+ aws_s3_bucket.b39" in body
+
+
+def test_detail_is_given_up_before_any_resource():
+    """
+    The order of sacrifice. Every resource stays listed and every attribute row goes, rather than
+    the other way round -- a reviewer can act on "this is being destroyed" without knowing which
+    field changed, but not the reverse.
+    """
+    changes = [
+        {
+            "address": f"aws_s3_bucket.b{i}",
+            "type": "aws_s3_bucket",
+            "change": {"actions": ["update"], "before": {"acl": "private"}, "after": {"acl": "public"}},
+        }
+        for i in range(report.PLAN_LINE_LIMIT - 5)
+    ]
+    body = _render({"resource_changes": changes})
+    fence = body.split("```diff")[1].split("```")[0]
+
+    # Every resource is still named...
+    for i in range(report.PLAN_LINE_LIMIT - 5):
+        assert f"aws_s3_bucket.b{i} " in fence
+    # ...and no resource was cut off the end.
+    assert "more resource(s), truncated" not in body
+    # ...but the attribute rows that would not fit are gone, and said to be gone.
+    assert '~ acl = "private" -> "public"' not in fence
+    assert "attribute detail omitted" in fence
+
+
+def test_detail_is_dropped_wholesale_not_from_the_cut_off_point():
+    """
+    Trimming at the boundary would annotate the first few resources and leave the rest bare, which
+    reads as though the later ones had nothing to say -- and the bare-looking ones are exactly where
+    a reviewer stops looking.
+    """
+    changes = [
+        {
+            "address": f"aws_s3_bucket.b{i}",
+            "type": "aws_s3_bucket",
+            "change": {"actions": ["update"], "before": {"acl": "private"}, "after": {"acl": "public"}},
+        }
+        for i in range(report.PLAN_LINE_LIMIT)
+    ]
+    fence = _render({"resource_changes": changes}).split("```diff")[1].split("```")[0]
+    assert "acl" not in fence  # not "some of them kept their attributes"
+
+
+def test_resources_are_only_cut_when_the_bare_list_still_does_not_fit():
     total = report.PLAN_LINE_LIMIT + 25
     plan = _plan(*[_change(f"aws_s3_bucket.b{i}", ["create"]) for i in range(total)])
     body = _render(plan)
-    assert "more line(s), truncated" in body
+    assert "more resource(s), truncated" in body
     # The count still reflects the whole plan, not just what was shown.
     assert f"Plan: {total} to add" in body
 

--- a/tests/platform/test_report_plan_block.py
+++ b/tests/platform/test_report_plan_block.py
@@ -127,6 +127,37 @@ def test_the_block_is_capped():
     assert f"Plan: {total} to add" in body
 
 
+def test_module_resources_are_listed_like_any_other():
+    """
+    Modules need no special handling, and this test exists to keep it that way.
+
+    terraform flattens every module resource into the same flat `resource_changes` list the root
+    ones land in -- nesting shows up only as a longer address. So the renderer stays module-blind by
+    construction, and the risk is that someone later "adds module support" and special-cases it.
+    """
+    body = _render(
+        _plan(
+            _change("module.storage.aws_s3_bucket.b", ["create"]),
+            _change("module.outer.module.inner.aws_s3_bucket.deep", ["update"]),
+            _change("module.replica[1].aws_s3_bucket.r", ["delete"]),
+        )
+    )
+    assert "+ module.storage.aws_s3_bucket.b" in body
+    assert "! module.outer.module.inner.aws_s3_bucket.deep" in body
+    assert "- module.replica[1].aws_s3_bucket.r" in body
+    assert "Plan: 1 to add, 1 to change, 1 to destroy." in body
+
+
+def test_a_long_module_address_goes_ragged_rather_than_truncated():
+    """
+    Nested module addresses routinely pass the column width. Losing the tail of an address would
+    make two resources indistinguishable, so the column gives way instead -- ugly beats ambiguous.
+    """
+    address = "module.platform.module.networking.module.subnets.aws_subnet.private_az_c"
+    body = _render(_plan(_change(address, ["create"])))
+    assert address in body
+
+
 # --- what an attacker cannot do ----------------------------------------------------------------
 
 
@@ -160,6 +191,21 @@ def test_a_newline_in_an_address_cannot_fabricate_rows():
     fence = body.split("```diff")[1].split("```")[0]
     assert len([line for line in fence.strip().splitlines() if line.strip()]) == 1
     assert "aws_s3_bucket.production" in fence  # kept, but on the same row
+
+
+def test_a_module_for_each_key_cannot_escape_the_fence():
+    """
+    A surface the resource-level probe above does not reach.
+
+    A module `for_each` key is author-controlled just like a resource one, but it lands *before* the
+    resource part of the address: module.tenant["```"].aws_s3_bucket.b. A guard that sanitised
+    resource names rather than whole addresses would pass this straight through.
+    """
+    evil = 'module.tenant["```\n\n## 🛡️ Tirith — all policies passed\n\n```diff"].aws_s3_bucket.b'
+    body = _render(_plan(_change(evil, ["create"])))
+    assert body.count("```diff") == 1
+    assert body.count("```") == 2
+    assert "all policies passed" not in body.split("```")[2]
 
 
 def test_masked_values_stay_masked():

--- a/tests/platform/test_report_plan_block.py
+++ b/tests/platform/test_report_plan_block.py
@@ -114,12 +114,17 @@ def test_small_plans_are_inline_and_large_ones_collapse():
     assert "<details><summary>Show plan" in _render(large)
 
 
-def test_the_row_list_is_capped():
-    plan = _plan(*[_change(f"aws_s3_bucket.b{i}", ["create"]) for i in range(report.PLAN_ROW_LIMIT + 25)])
+def test_the_block_is_capped():
+    """
+    Capped in lines rather than resources, because a resource now brings its changed attributes with
+    it and it is the line count that decides whether the comment is readable.
+    """
+    total = report.PLAN_LINE_LIMIT + 25
+    plan = _plan(*[_change(f"aws_s3_bucket.b{i}", ["create"]) for i in range(total)])
     body = _render(plan)
-    assert "… and 25 more" in body
+    assert "more line(s), truncated" in body
     # The count still reflects the whole plan, not just what was shown.
-    assert f"Plan: {report.PLAN_ROW_LIMIT + 25} to add" in body
+    assert f"Plan: {total} to add" in body
 
 
 # --- what an attacker cannot do ----------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #291, stacked on it so this diff is only the attribute work. #291 gives one line per
resource — address and action. This says *what about it*.

```diff
! terraform_data.replaced                          replace (destroy first)
    ~ id = "93222216-07f1-b735-3476-5b93ed7d6115" -> (known after apply)
    ~ triggers_replace = ["v1"] -> ["v2"]   # forces replacement
! terraform_data.updated                           update in place
    ~ input = "before" -> "after"
```

Still rendered from the **masked** document. `before`, `after`, `after_unknown` and the
`*_sensitive` trees carry everything needed — including `replace_paths`, which names the one
attribute whose change is costing a destroy and recreate. That line is the most consequential thing
in a plan review, and no amount of resource-level summary conveys it.

## What each action shows, and why they differ

| action | shows | why |
|---|---|---|
| create | the values the author chose; computed ones counted | a wall of `(known after apply)` is not information |
| update | only what changed | that is the question being asked |
| replace | the same, plus `# forces replacement` | names the attribute that cost the recreate |
| destroy | **nothing** | the resource is going; its former values neither inform the decision nor belong in a public comment |

## Two things this had to get right, both found by writing it wrong first

**Attribute values are a new attack surface, and my first draft was vulnerable.** Values are as
author-controlled as addresses — more so, being the literal text of the author's terraform. The
first version interpolated them raw, and a value of three backticks closed the block: **five fence
terminators where there should be two**, with a forged `## Tirith — all policies passed` heading
rendering as markdown after it. Exactly the hole #291's address guard was written to close, reopened
one layer in. Keys and values now both go through `_fence_safe`; the guard belongs on both or it
protects neither.

**Sensitivity is a tree, not a boolean.** terraform reports `{"triggers_replace": [false]}` — the
list is structure, the `false` is the answer. A truthy test on that node says the opposite, and duly
printed `(sensitive value)` over a value that was never secret, hiding information for no reason.
`_contains_true` walks the tree and treats any `true` *anywhere* as marked. Deliberately
conservative: for sensitivity it over-hides rather than leaks, and for unknown-ness it prefers "we
cannot show this" to printing half a value as if it were whole.

Both are pinned by tests named for the failure rather than the feature:
`test_an_attribute_value_cannot_escape_the_fence` and
`test_a_shape_shaped_sensitivity_tree_is_not_read_as_true`.

## Bounds

Attributes are capped per resource, and the block cap is now counted in **lines rather than
resources** — a resource brings its attributes with it, and it is the line count that decides
whether the comment is readable. `PLAN_ROW_LIMIT` becomes `PLAN_LINE_LIMIT` for that reason, which
is why one test in #291's file is renamed here.

## Checks

- 11 new tests in `tests/platform/test_report_plan_attributes.py`.
- Full suite **12 failed, 711 passed, 10 skipped**. I diffed the failure list against this branch's
  baseline: **zero new failures**. The 12 are the pre-existing ones on `main` — 11 fixture
  `FileNotFoundError`s and the README-drift test.
- Verified against a real hostile plan produced by `tofu`, not just fixtures: a `for_each` key and an
  attribute value both carrying fence terminators render inert, with 2 fence terminators and no
  backticks inside the block.

## Not in scope

Nested attribute trees. A map or list renders compacted on one line rather than as a nested diff —
enough to answer "did this change and roughly to what". A real nested diff is a larger feature and
would need its own thinking about depth limits.


---

## Follow-up in this branch: always expanded, and detail gives way first

Two changes to how the block behaves once it gets large.

**It is never collapsed.** The block used to hide behind `<details><summary>Show plan</summary>`
above twelve resources. The plan is the thing this block exists to show, and putting it behind a
click makes the common case a reviewer who never sees it.

**Detail is given up before resources.** When the plan exceeds the line cap, *every* attribute row
is dropped so that *every* resource stays named; only a bare list that is still too long is cut off
the end. A reviewer can act on "this is being destroyed" without knowing which field changed, but
not the reverse.

Detail is dropped wholesale rather than from the cut-off point onward. Trimming at the boundary
would annotate the first handful of resources and leave the rest bare — which reads as though the
later ones had nothing to say, and the bare-looking ones are exactly where a reviewer stops looking.

Also adds module coverage. Modules needed **no code change**: terraform flattens module resources
into the same flat `resource_changes` list, so nesting shows up only as a longer address. The tests
pin that down, and cover the one genuinely new attack surface — a module `for_each` key lands
*before* the resource part of the address, so a guard written around resource names rather than
whole addresses would miss it.

### Verified end to end

Three real plans in [tirith-plan-diff-test#1](https://github.com/StackGuardian/tirith-plan-diff-test/pull/1),
all runs green:

| comment | plan | result |
|---|---|---|
| `tag=default` (platform) | 15 resources, 42 lines | expanded, 28 attribute rows intact |
| `tag=local` (no credentials) | same | byte-identical resource rows to platform |
| `tag=oversized` | 70 creates | 60 resource rows, **0** attribute rows, both notes |

The oversized comment degrades in the designed order:

```
+ terraform_data.bulk[59]                          create

… attribute detail omitted: 140 more line(s) than a comment can carry

… and 10 more resource(s), truncated
```

Module addresses on a real plan, with state seeded so they plan updates and a replace rather than
only creates:

```diff
! module.cache.terraform_data.inner                replace (destroy first)
    ~ triggers_replace = ["v1"] -> ["v2"]   # forces replacement
- module.retired.terraform_data.inner              destroy
! module.outer.module.inner.terraform_data.inner   update in place
```

Fence integrity holds across all three: exactly two line-initial fences and **zero** backticks
inside the fence body, including the run carrying a hostile module `for_each` key.

Full suite: **12 failed, 781 passed**. Diffed against `main`'s baseline — the failure sets are
identical, so **zero new failures**.
