### PR TITLE
chore(release): 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
-## [Unreleased]
+## [1.2.1] - 2026-09-08
 
 ### Added
 - `tirith lint`: check policy files for the mistakes that otherwise reach CI looking like real

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ pip install -e .
 
 ```
 tirith --version
-tirith 1.2.0
+tirith 1.2.1
 ```
 
 Congratulations! Tirith has been setup in your system

--- a/docs/platform-check.md
+++ b/docs/platform-check.md
@@ -71,7 +71,7 @@ fabricated one would be worse than an honest `null`.
 ```json
 {
   "schema_version": 1,
-  "generator": {"name": "tirith", "version": "1.2.0"},
+  "generator": {"name": "tirith", "version": "1.2.1"},
   "created_at": "2026-08-12T09:14:03Z",
   "input_kind": "terraform_plan",
   "origin": {"kind": "ci", "trigger_type": "tirith", "ci_run_url": "https://github.com/acme/infra/actions/runs/1"},

--- a/documentation/docs/tirith-usage/ci-integration.md
+++ b/documentation/docs/tirith-usage/ci-integration.md
@@ -119,7 +119,7 @@ policy:
   image: python:3.12
   needs: [plan]
   script:
-    - pip install "git+https://github.com/StackGuardian/tirith.git@1.2.0"
+    - pip install "git+https://github.com/StackGuardian/tirith.git@1.2.1"
     - tirith -policy-path .tirith/policies -input-path plan.json --fail-on-error
 ```
 
@@ -129,7 +129,7 @@ will never come, and the job hangs instead of failing.
 
 Tirith is **not on PyPI** — `pip install tirith` installs an unrelated project of the same name.
 Install from git, and pin a tag rather than tracking the default branch so a CI job cannot change
-behaviour underneath you. `1.2.0` is the newest tag;
+behaviour underneath you. `1.2.1` is the newest tag;
 `git ls-remote --tags https://github.com/StackGuardian/tirith.git` lists them. Python 3.8 or newer.
 
 To evaluate your organization's policies instead of the committed files, swap the last line for
@@ -142,7 +142,7 @@ policy:
   variables:
     SG_ORG: my-org       # SG_API_TOKEN comes from a masked CI/CD variable
   script:
-    - pip install "git+https://github.com/StackGuardian/tirith.git@1.2.0"
+    - pip install "git+https://github.com/StackGuardian/tirith.git@1.2.1"
     - tirith platform check --workflow-id my-repo --input-path plan.json --fail-on-error
 ```
 
@@ -154,7 +154,7 @@ Nothing above is GitLab-specific: any runner that can execute a container and pr
 the same way. The recipe is always the same three steps —
 
 1. produce the input document (`terraform show -json tfplan > plan.json`);
-2. `pip install "git+https://github.com/StackGuardian/tirith.git@1.2.0"`;
+2. `pip install "git+https://github.com/StackGuardian/tirith.git@1.2.1"`;
 3. `tirith -policy-path <policies> -input-path plan.json --fail-on-error`
 
 — and gate the job on the exit code, which every CI system does by default for a non-zero exit.
@@ -182,7 +182,7 @@ pipelines:
       - step:
           name: Policy gate
           script:
-            - pip install "git+https://github.com/StackGuardian/tirith.git@1.2.0"
+            - pip install "git+https://github.com/StackGuardian/tirith.git@1.2.1"
             - tirith lint .tirith/policies   # needs a build from main until the next release
             - tirith -policy-path .tirith/policies -input-path plan.json --fail-on-error
 ```
@@ -226,7 +226,7 @@ Catch a broken policy before it is committed, let alone before CI runs it. Tirit
 ```yaml title=".pre-commit-config.yaml"
 repos:
   - repo: https://github.com/StackGuardian/tirith
-    rev: main          # 1.2.0 predates the hook; pin the first tag that includes it
+    rev: 1.2.1         # the first tag that publishes the hooks
     hooks:
       - id: tirith-lint
       - id: tirith-fmt

--- a/documentation/docs/tirith-usage/cli-reference.md
+++ b/documentation/docs/tirith-usage/cli-reference.md
@@ -139,7 +139,7 @@ passed. This is the flag that makes the command usable as a CI gate; the full co
 
 ### `--version`
 
-Prints the version number (for example `1.2.0`) and exits `0`.
+Prints the version number (for example `1.2.1`) and exits `0`.
 
 ## Output streams
 

--- a/documentation/docs/tirith-usage/editor-and-local.md
+++ b/documentation/docs/tirith-usage/editor-and-local.md
@@ -13,14 +13,6 @@ site_name: Tirith
 slug: editor-and-local/
 ---
 
-:::note Not in 1.2.0
-
-`tirith lint`, `tirith fmt` and the pre-commit hooks are on `main` and will be in the next
-release. `pip install "git+https://github.com/StackGuardian/tirith.git@1.2.0"` does not have them;
-install from `main` until then.
-
-:::
-
 CI is the last place a policy should fail. This page is about the loop before that — running
 Tirith on your own machine, while the code is still being written.
 
@@ -79,7 +71,7 @@ the interactive explorer — is
 ```yaml title=".pre-commit-config.yaml"
 repos:
   - repo: https://github.com/StackGuardian/tirith
-    rev: main          # 1.2.0 predates the hooks; pin the first tag that includes them
+    rev: 1.2.1         # the first tag that publishes the hooks
     hooks:
       - id: tirith-lint
       - id: tirith-fmt

--- a/documentation/static/docs/tirith-usage/ci-integration.md
+++ b/documentation/static/docs/tirith-usage/ci-integration.md
@@ -107,7 +107,7 @@ policy:
   image: python:3.12
   needs: [plan]
   script:
-    - pip install "git+https://github.com/StackGuardian/tirith.git@1.2.0"
+    - pip install "git+https://github.com/StackGuardian/tirith.git@1.2.1"
     - tirith -policy-path .tirith/policies -input-path plan.json --fail-on-error
 ```
 
@@ -117,7 +117,7 @@ will never come, and the job hangs instead of failing.
 
 Tirith is **not on PyPI** — `pip install tirith` installs an unrelated project of the same name.
 Install from git, and pin a tag rather than tracking the default branch so a CI job cannot change
-behaviour underneath you. `1.2.0` is the newest tag;
+behaviour underneath you. `1.2.1` is the newest tag;
 `git ls-remote --tags https://github.com/StackGuardian/tirith.git` lists them. Python 3.8 or newer.
 
 To evaluate your organization's policies instead of the committed files, swap the last line for
@@ -130,7 +130,7 @@ policy:
   variables:
     SG_ORG: my-org       # SG_API_TOKEN comes from a masked CI/CD variable
   script:
-    - pip install "git+https://github.com/StackGuardian/tirith.git@1.2.0"
+    - pip install "git+https://github.com/StackGuardian/tirith.git@1.2.1"
     - tirith platform check --workflow-id my-repo --input-path plan.json --fail-on-error
 ```
 
@@ -142,7 +142,7 @@ Nothing above is GitLab-specific: any runner that can execute a container and pr
 the same way. The recipe is always the same three steps —
 
 1. produce the input document (`terraform show -json tfplan > plan.json`);
-2. `pip install "git+https://github.com/StackGuardian/tirith.git@1.2.0"`;
+2. `pip install "git+https://github.com/StackGuardian/tirith.git@1.2.1"`;
 3. `tirith -policy-path <policies> -input-path plan.json --fail-on-error`
 
 — and gate the job on the exit code, which every CI system does by default for a non-zero exit.
@@ -170,7 +170,7 @@ pipelines:
       - step:
           name: Policy gate
           script:
-            - pip install "git+https://github.com/StackGuardian/tirith.git@1.2.0"
+            - pip install "git+https://github.com/StackGuardian/tirith.git@1.2.1"
             - tirith lint .tirith/policies   # needs a build from main until the next release
             - tirith -policy-path .tirith/policies -input-path plan.json --fail-on-error
 ```
@@ -214,7 +214,7 @@ Catch a broken policy before it is committed, let alone before CI runs it. Tirit
 ```yaml
 repos:
   - repo: https://github.com/StackGuardian/tirith
-    rev: main          # 1.2.0 predates the hook; pin the first tag that includes it
+    rev: 1.2.1         # the first tag that publishes the hooks
     hooks:
       - id: tirith-lint
       - id: tirith-fmt

--- a/documentation/static/docs/tirith-usage/cli-reference.md
+++ b/documentation/static/docs/tirith-usage/cli-reference.md
@@ -132,7 +132,7 @@ passed. This is the flag that makes the command usable as a CI gate; the full co
 
 ### `--version`
 
-Prints the version number (for example `1.2.0`) and exits `0`.
+Prints the version number (for example `1.2.1`) and exits `0`.
 
 ## Output streams
 

--- a/documentation/static/docs/tirith-usage/editor-and-local.md
+++ b/documentation/static/docs/tirith-usage/editor-and-local.md
@@ -3,13 +3,6 @@
 Source: https://stackguardian.github.io/tirith/docs/tirith-usage/editor-and-local/
 Summary: VS Code tasks, a pre-commit hook, and the local loop to use when an AI agent is drafting the policy.
 
-[NOTE] Not in 1.2.0
-
-`tirith lint`, `tirith fmt` and the pre-commit hooks are on `main` and will be in the next
-release. `pip install "git+https://github.com/StackGuardian/tirith.git@1.2.0"` does not have them;
-install from `main` until then.
-
-
 CI is the last place a policy should fail. This page is about the loop before that — running
 Tirith on your own machine, while the code is still being written.
 
@@ -68,7 +61,7 @@ the interactive explorer — is
 ```yaml
 repos:
   - repo: https://github.com/StackGuardian/tirith
-    rev: main          # 1.2.0 predates the hooks; pin the first tag that includes them
+    rev: 1.2.1         # the first tag that publishes the hooks
     hooks:
       - id: tirith-lint
       - id: tirith-fmt

--- a/documentation/static/llms-full.txt
+++ b/documentation/static/llms-full.txt
@@ -2773,7 +2773,7 @@ passed. This is the flag that makes the command usable as a CI gate; the full co
 
 ### `--version`
 
-Prints the version number (for example `1.2.0`) and exits `0`.
+Prints the version number (for example `1.2.1`) and exits `0`.
 
 ## Output streams
 
@@ -2982,7 +2982,7 @@ policy:
   image: python:3.12
   needs: [plan]
   script:
-    - pip install "git+https://github.com/StackGuardian/tirith.git@1.2.0"
+    - pip install "git+https://github.com/StackGuardian/tirith.git@1.2.1"
     - tirith -policy-path .tirith/policies -input-path plan.json --fail-on-error
 ```
 
@@ -2992,7 +2992,7 @@ will never come, and the job hangs instead of failing.
 
 Tirith is **not on PyPI** — `pip install tirith` installs an unrelated project of the same name.
 Install from git, and pin a tag rather than tracking the default branch so a CI job cannot change
-behaviour underneath you. `1.2.0` is the newest tag;
+behaviour underneath you. `1.2.1` is the newest tag;
 `git ls-remote --tags https://github.com/StackGuardian/tirith.git` lists them. Python 3.8 or newer.
 
 To evaluate your organization's policies instead of the committed files, swap the last line for
@@ -3005,7 +3005,7 @@ policy:
   variables:
     SG_ORG: my-org       # SG_API_TOKEN comes from a masked CI/CD variable
   script:
-    - pip install "git+https://github.com/StackGuardian/tirith.git@1.2.0"
+    - pip install "git+https://github.com/StackGuardian/tirith.git@1.2.1"
     - tirith platform check --workflow-id my-repo --input-path plan.json --fail-on-error
 ```
 
@@ -3017,7 +3017,7 @@ Nothing above is GitLab-specific: any runner that can execute a container and pr
 the same way. The recipe is always the same three steps —
 
 1. produce the input document (`terraform show -json tfplan > plan.json`);
-2. `pip install "git+https://github.com/StackGuardian/tirith.git@1.2.0"`;
+2. `pip install "git+https://github.com/StackGuardian/tirith.git@1.2.1"`;
 3. `tirith -policy-path <policies> -input-path plan.json --fail-on-error`
 
 — and gate the job on the exit code, which every CI system does by default for a non-zero exit.
@@ -3045,7 +3045,7 @@ pipelines:
       - step:
           name: Policy gate
           script:
-            - pip install "git+https://github.com/StackGuardian/tirith.git@1.2.0"
+            - pip install "git+https://github.com/StackGuardian/tirith.git@1.2.1"
             - tirith lint .tirith/policies   # needs a build from main until the next release
             - tirith -policy-path .tirith/policies -input-path plan.json --fail-on-error
 ```
@@ -3089,7 +3089,7 @@ Catch a broken policy before it is committed, let alone before CI runs it. Tirit
 ```yaml
 repos:
   - repo: https://github.com/StackGuardian/tirith
-    rev: main          # 1.2.0 predates the hook; pin the first tag that includes it
+    rev: 1.2.1         # the first tag that publishes the hooks
     hooks:
       - id: tirith-lint
       - id: tirith-fmt
@@ -3252,13 +3252,6 @@ Source: https://stackguardian.github.io/tirith/docs/tirith-usage/editor-and-loca
 Summary: VS Code tasks, a pre-commit hook, and the local loop to use when an AI agent is drafting the policy.
 ==============================================================================
 
-[NOTE] Not in 1.2.0
-
-`tirith lint`, `tirith fmt` and the pre-commit hooks are on `main` and will be in the next
-release. `pip install "git+https://github.com/StackGuardian/tirith.git@1.2.0"` does not have them;
-install from `main` until then.
-
-
 CI is the last place a policy should fail. This page is about the loop before that — running
 Tirith on your own machine, while the code is still being written.
 
@@ -3317,7 +3310,7 @@ the interactive explorer — is
 ```yaml
 repos:
   - repo: https://github.com/StackGuardian/tirith
-    rev: main          # 1.2.0 predates the hooks; pin the first tag that includes them
+    rev: 1.2.1         # the first tag that publishes the hooks
     hooks:
       - id: tirith-lint
       - id: tirith-fmt

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def read(*names, **kwargs):
 
 setup(
     name="py-tirith",
-    version="1.2.0",
+    version="1.2.1",
     license="Apache",
     description="Tirith simplifies defining Policy as Code.",
     long_description_content_type="text/markdown",

--- a/src/tirith/__init__.py
+++ b/src/tirith/__init__.py
@@ -2,6 +2,6 @@
 tirith: Execute policies defined using Tirith (StackGuardian Policy Framework)
 """
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 __author__ = "StackGuardian"
 __license__ = "Apache"

--- a/src/tirith/platform/report.py
+++ b/src/tirith/platform/report.py
@@ -180,7 +180,6 @@ def _fit_plan_rows(entries):
     return bare[:PLAN_LINE_LIMIT], hidden_detail, len(bare) - PLAN_LINE_LIMIT
 
 
-
 def summarize(policy_results):
     """
     Collapse the results into counts plus a flat finding list.

--- a/tests/platform/test_report_plan_attributes.py
+++ b/tests/platform/test_report_plan_attributes.py
@@ -12,9 +12,7 @@ from tirith.platform import report
 
 
 def _render(changes):
-    return report.render_markdown(
-        {}, "COMPLETED", "https://example.invalid/run", plan={"resource_changes": changes}
-    )
+    return report.render_markdown({}, "COMPLETED", "https://example.invalid/run", plan={"resource_changes": changes})
 
 
 def _fence(body):
@@ -106,8 +104,10 @@ def test_the_attribute_that_forces_a_replacement_is_named():
     )
     fence = _fence(body)
     assert "# forces replacement" in fence
-    assert [line for line in fence.splitlines() if "forces replacement" in line][0].lstrip().startswith(
-        "~ triggers_replace"
+    assert (
+        [line for line in fence.splitlines() if "forces replacement" in line][0]
+        .lstrip()
+        .startswith("~ triggers_replace")
     )
 
 

--- a/tests/platform/test_report_plan_block.py
+++ b/tests/platform/test_report_plan_block.py
@@ -281,8 +281,6 @@ def test_the_plan_is_dropped_before_any_finding():
         ]
     }
     plan = _plan(*[_change(f"aws_s3_bucket.b{i}", ["create"]) for i in range(20)])
-    body = report.render_markdown(
-        results, "COMPLETED", "https://example.invalid/run", plan=plan, limit=3000
-    )
+    body = report.render_markdown(results, "COMPLETED", "https://example.invalid/run", plan=plan, limit=3000)
     assert "```diff" not in body
     assert "policy-a" in body


### PR DESCRIPTION
Closes https://github.com/StackGuardian/tirith/issues/371

Everything under `## [Unreleased]` has been on `main` since `1.2.0` (2026-08-03) and is unreachable from a pinned install — `tirith lint`, `tirith fmt`, the pre-commit hooks, `tirith ui`, the result `context` on messages, and the `error_tolerance` verdict fix (#293). This cuts the tag that makes them installable.

## What changed

| File | Change |
| --- | --- |
| `CHANGELOG.md` | `## [Unreleased]` → `## [1.2.1] - 2026-09-08`. Content untouched. |
| `setup.py`, `src/tirith/__init__.py` | `1.2.0` → `1.2.1` |
| `README.md` | install-verification output; `tests/test_readme_is_current.py` pins it to `__version__` |
| `documentation/docs/tirith-usage/*` | install pins `@1.2.0` → `@1.2.1`; "`1.2.0` is the newest tag" |
| `documentation/docs/tirith-usage/editor-and-local.md` | dropped the ":::note Not in 1.2.0" admonition — the release contains what it was about |
| both pre-commit blocks | `rev: main` → `rev: 1.2.1`, which is the point of publishing `.pre-commit-hooks.yaml` |
| `docs/platform-check.md` | the `generator.version` in the sample result document |
| `documentation/static/**` | regenerated by `documentation/scripts/generate-llms-full.py`, as its docstring asks |

## After merge

Tag and push, or the install pins in this PR resolve to nothing:

```
git tag -a 1.2.1 -m 'Release 1.2.1' && git push origin 1.2.1
```

Note the tags in this repo are unprefixed (`1.2.0`, `1.0.6`) — `bump_version.py` prints a `v`-prefixed suggestion that does not match what is actually published.

## On the version number

Semver would make this `1.3.0`: `tirith lint`, `tirith fmt` and `tirith ui` are new commands, and the changelog's `Added` section is the longest part of it. Cut as `1.2.1` as asked; say the word and I will move it.

## Deliberately not in this PR

The landing page and the agent-facing packs still describe `tirith lint` as unshipped, and still pin `@1.2.0`:

- `documentation/src/pages/index.js` — the "Any CI" tab keeps `tirith lint` commented out, and the `anywhere` section carries an `IN DEV` badge
- `documentation/src/data/demoPhases.js` — five commented `# in dev, not in 1.2.0` lines, and `inDev: true` on the pre-commit integration
- `documentation/static/llms.txt` → `src/data/agentBrief.js` — "**`tirith lint` is not in the released package**"
- `.cursor/rules/tirith-policies.mdc`, `.claude/skills/tirith-policies/` — the same claim, plus "do not put it in a pipeline"

Uncommenting those, flipping the `IN DEV` badge to `BETA`, and moving the tense out of the conditional is copy and badge work with its own review surface, and half-doing it here would leave a pin that says `1.2.1` next to a caveat that says `not in 1.2.0`. Each file group is internally consistent as it stands. Follow-up.