### PR TITLE
docs: pin the GitHub Action at v2.1.1

### DIFF
--- a/.claude/skills/tirith-policies/reference/pipelines.md
+++ b/.claude/skills/tirith-policies/reference/pipelines.md
@@ -51,7 +51,7 @@ steps:
   - uses: actions/checkout@v4
   - run: terraform plan -out=tfplan -input=false
 
-  - uses: StackGuardian/tirith-iac-governance-action@v2
+  - uses: StackGuardian/tirith-iac-governance-action@v2.1.1
     with:
       plan-file: tfplan
       fail-on-error: true

--- a/.cursor/rules/tirith-policies.mdc
+++ b/.cursor/rules/tirith-policies.mdc
@@ -89,7 +89,7 @@ steps:
   - run: |
       terraform plan -out=tfplan -input=false
       terraform show -json tfplan > plan.json
-  - uses: StackGuardian/tirith-iac-governance-action@v2
+  - uses: StackGuardian/tirith-iac-governance-action@v2.1.1
     with: {fail-on-error: true}
 ```
 

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ code:
 
 ```yaml
 - run: terraform show -json tfplan > plan.json
-- uses: StackGuardian/tirith-iac-governance-action@v2
+- uses: StackGuardian/tirith-iac-governance-action@v2.1.1
 ```
 
 With a `plan.json` in the working directory that is the whole integration — no `with:` block. Add

--- a/documentation/docs/tirith-usage/ci-integration.md
+++ b/documentation/docs/tirith-usage/ci-integration.md
@@ -47,7 +47,7 @@ steps:
       terraform plan -out=tfplan -input=false
       terraform show -json tfplan > plan.json
 
-  - uses: StackGuardian/tirith-iac-governance-action@v2
+  - uses: StackGuardian/tirith-iac-governance-action@v2.1.1
 ```
 
 With a `plan.json` in the working directory that is the whole integration — no `with:` block. The

--- a/documentation/src/data/demoPhases.js
+++ b/documentation/src/data/demoPhases.js
@@ -25,7 +25,7 @@ export const DEMO_PHASES = [
   checks: write
 
 - run: terraform show -json tfplan > plan.json
-- uses: StackGuardian/tirith-iac-governance-action@v2
+- uses: StackGuardian/tirith-iac-governance-action@v2.1.1
   with:
     fail-on-error: true`,
     outcome: {
@@ -54,7 +54,7 @@ export const DEMO_PHASES = [
       'files are removed.',
     delta: '4 files · +5 −77',
     tag: 'Optional platform',
-    code: `- uses: StackGuardian/tirith-iac-governance-action@v2
+    code: `- uses: StackGuardian/tirith-iac-governance-action@v2.1.1
   with:
     sg-api-key: \${{ secrets.SG_API_TOKEN }}
     sg-org: \${{ vars.SG_ORG }}
@@ -154,7 +154,7 @@ export const DEMO_PHASES = [
     tag: 'Post-apply',
     code: `- run: terraform show -json > state.json
 
-- uses: StackGuardian/tirith-iac-governance-action@v2
+- uses: StackGuardian/tirith-iac-governance-action@v2.1.1
   continue-on-error: true
   with:
     input-path: state.json
@@ -212,7 +212,7 @@ export const PIPELINE_TARGETS = [
 steps:
   - run: terraform plan -out=tfplan -input=false
 
-  - uses: StackGuardian/tirith-iac-governance-action@v2
+  - uses: StackGuardian/tirith-iac-governance-action@v2.1.1
     with:
       plan-file: tfplan
       fail-on-error: true`,
@@ -304,7 +304,7 @@ export const DEMO_REPOS = [
 
 steps:
   - run: terraform show -json tfplan > plan.json
-  - uses: StackGuardian/tirith-iac-governance-action@v2
+  - uses: StackGuardian/tirith-iac-governance-action@v2.1.1
     with:
       fail-on-error: true`,
   },

--- a/documentation/src/pages/index.js
+++ b/documentation/src/pages/index.js
@@ -130,7 +130,7 @@ const hero = {
        */
       command: `- run: terraform plan -out=tfplan -input=false
 
-- uses: StackGuardian/tirith-iac-governance-action@v2
+- uses: StackGuardian/tirith-iac-governance-action@v2.1.1
   with:
     plan-file: tfplan
     fail-on-error: true`,

--- a/documentation/static/docs/tirith-usage/ci-integration.md
+++ b/documentation/static/docs/tirith-usage/ci-integration.md
@@ -35,7 +35,7 @@ steps:
       terraform plan -out=tfplan -input=false
       terraform show -json tfplan > plan.json
 
-  - uses: StackGuardian/tirith-iac-governance-action@v2
+  - uses: StackGuardian/tirith-iac-governance-action@v2.1.1
 ```
 
 With a `plan.json` in the working directory that is the whole integration — no `with:` block. The

--- a/documentation/static/llms-full.txt
+++ b/documentation/static/llms-full.txt
@@ -2910,7 +2910,7 @@ steps:
       terraform plan -out=tfplan -input=false
       terraform show -json tfplan > plan.json
 
-  - uses: StackGuardian/tirith-iac-governance-action@v2
+  - uses: StackGuardian/tirith-iac-governance-action@v2.1.1
 ```
 
 With a `plan.json` in the working directory that is the whole integration — no `with:` block. The


### PR DESCRIPTION
Every snippet showing the GitHub Action pinned `@v2`, which installs py-tirith **1.2.0**. Two
releases have shipped since.

## Why it matters that this is manual

The action pins its CLI to an exact tag on purpose — one action ref means one known CLI, so a
caller's green pipeline cannot turn red with nothing in their repository changing. The cost is that
`@v2` never drifts: anyone copying our snippets stays on 1.2.0 until we move the docs deliberately.

`@v2.1.1` installs 1.2.1, whose comment renders the **planned changes** as a `diff` block above the
findings table — one row per changing resource with the attributes that move underneath it, from the
masked plan. [`v2.1.0`](https://github.com/StackGuardian/tirith-iac-governance-action/releases/tag/v2.1.0)
shipped that for the platform path and [`v2.1.1`](https://github.com/StackGuardian/tirith-iac-governance-action/releases/tag/v2.1.1)
added the local-mode path it had missed, so `v2.1.1` is the first tag where the feature is true in
both modes.

## The diff

Ten references, one substitution, nothing else:

| file | refs |
|---|---|
| `README.md` | 1 |
| `documentation/src/pages/index.js` — the landing page | 1 |
| `documentation/src/data/demoPhases.js` | 5 |
| `documentation/docs/tirith-usage/ci-integration.md` | 1 |
| `.cursor/rules/tirith-policies.mdc`, `.claude/skills/tirith-policies/reference/pipelines.md` | 2 |

The two agent-facing packs are included because leaving them behind hands an agent a stale pin, which
is the copy most likely to be followed without checking.

`static/llms-full.txt` and `static/docs/` are **regenerated** with
`documentation/scripts/generate-llms-full.py`, not hand-edited — that script exists precisely so
those files are not a second source of truth. Their only change is the same version line.

Every changed line in the whole PR:

```
-  - uses: StackGuardian/tirith-iac-governance-action@v2
+  - uses: StackGuardian/tirith-iac-governance-action@v2.1.1
```

## Two things I found and deliberately left alone

Both belong in their own change rather than smuggled into a version bump:

- The **GitLab snippet** in `README.md` and `ci-integration.md` installs
  `tirith.git@1.0.5` — five releases stale.
- Both files state **"There is no GitLab-native equivalent of the action"**, which stopped being true
  when the GitLab CI/CD component was published to the catalog.

Noted in #373 so they are not lost.

Closes #373
